### PR TITLE
fix(ui): use data-has-content to hide empty card header/footer

### DIFF
--- a/packages/ui/src/components/card/card.css
+++ b/packages/ui/src/components/card/card.css
@@ -48,7 +48,7 @@
     border-block-end: 1px solid var(--g-theme-color-border-default);
   }
 
-  .card__header:has(> slot:empty) {
+  .card__header:not([data-has-content]) {
     display: none;
   }
 
@@ -87,7 +87,7 @@
     background: var(--g-theme-color-background-default);
   }
 
-  .card__footer:has(> slot:empty) {
+  .card__footer:not([data-has-content]) {
     display: none;
   }
 


### PR DESCRIPTION
## Summary

- Replaces `.card__header:has(> slot:empty)` and `.card__footer:has(> slot:empty)` with `:not([data-has-content])` in `card.css`
- `:empty` on a shadow DOM `<slot>` only checks the slot's own fallback children, not assigned light DOM nodes — so the header/footer were always hidden when slots had no fallback content written inline
- The component already tracks slot assignment correctly via `_checkSlots()` which toggles `data-has-content` on the header/footer elements; the CSS just wasn't using it

Fixes #38