### PR TITLE
fix: add .light sub-element override CSS and fix ::selection token

### DIFF
--- a/packages/style-dictionary/config.js
+++ b/packages/style-dictionary/config.js
@@ -1,5 +1,5 @@
 import StyleDictionary from "style-dictionary";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import minimist from "minimist";
 
 /**
@@ -704,6 +704,38 @@ const hasDarkTokens = (themeName) => {
 };
 
 /**
+ * Build light.css for a theme — outputs all --g-theme-* variables scoped to .light { }.
+ * This enables forcing light mode on any element or subtree within a .dark parent.
+ * Reads the already-built tokens.css to extract theme-scoped variables.
+ * @param {string} themeName
+ */
+const buildLightCSS = (themeName) => {
+	const tokensCssPath = `./dist/css/${themeName}/tokens.css`;
+	const css = readFileSync(tokensCssPath, "utf-8");
+
+	/* Extract only --g-theme-* variables (tier-2/tier-3) — those are what dark mode overrides */
+	const lines = [];
+	const re = /\s*(--g-theme-[\w-]+):\s*(.+?);/g;
+	for (const match of css.matchAll(re)) {
+		lines.push(`  ${match[1]}: ${match[2]};`);
+	}
+
+	const output = [
+		`/* Light mode override for ${themeName} theme */`,
+		`/* Force light mode on any element or subtree within a .dark parent */`,
+		`.light {`,
+		[...new Set(lines)].join("\n"),
+		`}`,
+		``,
+	].join("\n");
+
+	const outDir = `./dist/css/${themeName}/`;
+	mkdirSync(outDir, { recursive: true });
+	writeFileSync(`${outDir}light.css`, output, "utf-8");
+	console.log(`✔︎ dist/css/${themeName}/light.css`);
+};
+
+/**
  * Build the tokens
  * 1) If no theme is specified, build all themes
  * 2) Otherwise, build the specified theme
@@ -714,6 +746,9 @@ const buildTheme = async (themeName) => {
 	const themeConfig = getStyleDictionaryConfig(themeName);
 	const StyleDictionaryExtended = new StyleDictionary(themeConfig);
 	await StyleDictionaryExtended.buildAllPlatforms();
+
+	console.log(`☀️ Building ${themeName.toUpperCase()} light override`);
+	buildLightCSS(themeName);
 
 	if (hasDarkTokens(themeName)) {
 		console.log(`🌙 Building ${themeName.toUpperCase()} dark theme`);

--- a/packages/style-dictionary/package.json
+++ b/packages/style-dictionary/package.json
@@ -25,6 +25,10 @@
 		"./grantcodes/css/dark": "./dist/css/grantcodes/dark.css",
 		"./todomap/css/dark": "./dist/css/todomap/dark.css",
 		"./grantina/css/dark": "./dist/css/grantina/dark.css",
+		"./wireframe/css/light": "./dist/css/wireframe/light.css",
+		"./grantcodes/css/light": "./dist/css/grantcodes/light.css",
+		"./todomap/css/light": "./dist/css/todomap/light.css",
+		"./grantina/css/light": "./dist/css/grantina/light.css",
 		"./assets/fonts/greycliff": "./assets/fonts/greycliff.css",
 		"./assets/fonts/quicksand": "./assets/fonts/quicksand.css",
 		"./assets/fonts/grantina": "./assets/fonts/grantina.css"

--- a/packages/ui/src/css/base.css
+++ b/packages/ui/src/css/base.css
@@ -238,7 +238,7 @@ pre {
 }
 
 ::selection {
-	background-color: var(--g-color-brand-purple-200);
+	background-color: var(--g-theme-color-background-brand);
 }
 
 /* Default backdrop styles */

--- a/packages/ui/src/css/themes/grantcodes.css
+++ b/packages/ui/src/css/themes/grantcodes.css
@@ -1,4 +1,5 @@
 @import "@grantcodes/style-dictionary/grantcodes/css";
 @import "@grantcodes/style-dictionary/grantcodes/css/theme";
 @import "@grantcodes/style-dictionary/grantcodes/css/dark";
+@import "@grantcodes/style-dictionary/grantcodes/css/light";
 @import "@grantcodes/style-dictionary/assets/fonts/greycliff";

--- a/packages/ui/src/css/themes/grantina.css
+++ b/packages/ui/src/css/themes/grantina.css
@@ -1,4 +1,5 @@
 @import "@grantcodes/style-dictionary/grantina/css";
 @import "@grantcodes/style-dictionary/grantina/css/theme";
 @import "@grantcodes/style-dictionary/grantina/css/dark";
+@import "@grantcodes/style-dictionary/grantina/css/light";
 @import "@grantcodes/style-dictionary/assets/fonts/grantina";

--- a/packages/ui/src/css/themes/todomap.css
+++ b/packages/ui/src/css/themes/todomap.css
@@ -1,6 +1,7 @@
 @import "@grantcodes/style-dictionary/todomap/css";
 @import "@grantcodes/style-dictionary/todomap/css/theme";
 @import "@grantcodes/style-dictionary/todomap/css/dark";
+@import "@grantcodes/style-dictionary/todomap/css/light";
 @import "@grantcodes/style-dictionary/assets/fonts/quicksand";
 
 html.todomap {

--- a/packages/ui/src/css/themes/wireframe.css
+++ b/packages/ui/src/css/themes/wireframe.css
@@ -1,3 +1,4 @@
 @import "@grantcodes/style-dictionary/wireframe/css";
 @import "@grantcodes/style-dictionary/wireframe/css/theme";
 @import "@grantcodes/style-dictionary/wireframe/css/dark";
+@import "@grantcodes/style-dictionary/wireframe/css/light";


### PR DESCRIPTION
## Summary

Follow-up fixes for the dark theme implementation (#43):

- **`.light` sub-element override** — Each theme now builds a `light.css` with all `--g-theme-*` variables scoped to `.light {}`. This enables forcing light mode on any element or subtree (e.g. inside a `.dark` parent). Previously `.light` only worked on `:root` via `:root:not(.light)` in the media query.
- **Package exports** — Added `./*/css/light` exports for all 4 themes to `package.json`
- **Theme CSS imports** — All 4 UI theme CSS files now import the light override CSS
- **`::selection` token** — Changed `base.css` `::selection` from hardcoded `var(--g-color-brand-purple-200)` (tier-1, theme-agnostic) to `var(--g-theme-color-background-brand)` (tier-2, adapts to theme and dark mode)

## How it works

```css
/* Force light mode on a subtree inside a .dark parent */
<div class="dark">
  <div class="light">
    <!-- These components render in light mode -->
  </div>
</div>
```

The `light.css` is generated by parsing the built `tokens.css` and extracting all `--g-theme-*` variables, outputting them under a `.light {}` selector. No additional Style Dictionary build pass needed.