### PR TITLE
fix(gallery): SSR-safe filmstrip variant with variant prop refactor

### DIFF
--- a/packages/ui/src/components/gallery/gallery-image.component.js
+++ b/packages/ui/src/components/gallery/gallery-image.component.js
@@ -12,7 +12,6 @@ export class GrantCodesGalleryImage extends LitElement {
 		alt: { type: String },
 		caption: { type: String },
 		thumbnail: { type: String },
-		filmstrip: { type: Boolean, reflect: true },
 	};
 
 	constructor() {
@@ -24,7 +23,6 @@ export class GrantCodesGalleryImage extends LitElement {
 		this.alt = "";
 		this.caption = "";
 		this.thumbnail = "";
-		this.filmstrip = false;
 	}
 
 	captionTemplate() {

--- a/packages/ui/src/components/gallery/gallery.component.js
+++ b/packages/ui/src/components/gallery/gallery.component.js
@@ -6,7 +6,7 @@ export class GrantCodesGallery extends LitElement {
 	static styles = [galleryStyles];
 
 	static properties = {
-		filmstrip: { type: Boolean, reflect: true },
+		variant: { type: String, reflect: true },
 	};
 
 	/** @type {any[]} */
@@ -14,7 +14,7 @@ export class GrantCodesGallery extends LitElement {
 
 	constructor() {
 		super();
-		this.filmstrip = false;
+		this.variant = "default";
 	}
 
 	render() {

--- a/packages/ui/src/components/gallery/gallery.component.js
+++ b/packages/ui/src/components/gallery/gallery.component.js
@@ -17,33 +17,6 @@ export class GrantCodesGallery extends LitElement {
 		this.filmstrip = false;
 	}
 
-	firstUpdated() {
-		const slot = this.renderRoot.querySelector(".gallery__slot");
-		if (slot) {
-			slot.addEventListener("slotchange", () => this._updateChildren());
-			this._updateChildren();
-		}
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has("filmstrip")) {
-			this._updateChildren();
-		}
-	}
-
-	_updateChildren() {
-		const slot = this.renderRoot.querySelector(".gallery__slot");
-		if (!slot) return;
-		const assigned = slot.assignedElements({ flatten: true });
-		for (const el of assigned) {
-			if (this.filmstrip) {
-				el.setAttribute("filmstrip", "");
-			} else {
-				el.removeAttribute("filmstrip");
-			}
-		}
-	}
-
 	render() {
 		return html`
       <div class="gallery">

--- a/packages/ui/src/components/gallery/gallery.css
+++ b/packages/ui/src/components/gallery/gallery.css
@@ -59,7 +59,19 @@
    FILMSTRIP VARIANT
    ============================================= */
 
-/* Gallery container in filmstrip mode */
+/* Set inherited CSS custom properties on the gallery host when in filmstrip
+   mode. These cascade down to slotted grantcodes-gallery-image children
+   without requiring JS attribute propagation, making the filmstrip work
+   correctly with SSR-rendered content. */
+:host([filmstrip]) {
+  --_filmstrip-image-block-size: 100%;
+  --_filmstrip-image-width: fit-content;
+  --_filmstrip-img-block-size: 100%;
+  --_filmstrip-img-width: auto;
+  --_filmstrip-img-aspect-ratio: unset;
+  --_filmstrip-img-max-inline-size: none;
+}
+
 :host([filmstrip]) .gallery {
   overflow: hidden;
 }
@@ -108,7 +120,25 @@
   }
 }
 
-/* Gallery-image host in filmstrip mode */
+/* Gallery-image filmstrip styles. These rules live in the gallery-image
+   shadow DOM context (:host = grantcodes-gallery-image). They read the
+   --_filmstrip-* custom properties inherited from the parent gallery
+   component, so they work without a filmstrip attribute on the image
+   element itself. The [filmstrip] attribute selector is kept as a
+   fallback for direct attribute usage. */
+:host .gallery__image {
+  block-size: var(--_filmstrip-image-block-size, auto);
+  width: var(--_filmstrip-image-width, 100%);
+}
+
+:host .gallery__image img {
+  block-size: var(--_filmstrip-img-block-size, auto);
+  width: var(--_filmstrip-img-width, 100%);
+  aspect-ratio: var(--_filmstrip-img-aspect-ratio, 1);
+  max-inline-size: var(--_filmstrip-img-max-inline-size, unset);
+}
+
+/* Attribute-based fallback (e.g. filmstrip set directly on the image) */
 :host([filmstrip]) .gallery__image {
   block-size: 100%;
   width: fit-content;
@@ -119,7 +149,4 @@
   width: auto;
   aspect-ratio: unset;
   max-inline-size: none;
-  object-fit: cover;
-  object-position: center;
 }
-

--- a/packages/ui/src/components/gallery/gallery.css
+++ b/packages/ui/src/components/gallery/gallery.css
@@ -82,7 +82,7 @@
    mode. These cascade down to slotted grantcodes-gallery-image children
    without requiring JS attribute propagation, making the filmstrip work
    correctly with SSR-rendered content. */
-:host([filmstrip]) {
+:host([variant="filmstrip"]) {
   --_gallery-image-block-size: 100%;
   --_gallery-image-width: fit-content;
   --_gallery-img-aspect-ratio: auto;
@@ -92,11 +92,11 @@
   --_gallery-img-max-inline-size: none;
 }
 
-:host([filmstrip]) .gallery {
+:host([variant="filmstrip"]) .gallery {
   overflow: hidden;
 }
 
-:host([filmstrip]) .gallery__slot {
+:host([variant="filmstrip"]) .gallery__slot {
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
@@ -108,11 +108,11 @@
   scrollbar-width: none;
 }
 
-:host([filmstrip]) .gallery__slot::-webkit-scrollbar {
+:host([variant="filmstrip"]) .gallery__slot::-webkit-scrollbar {
   display: none;
 }
 
-:host([filmstrip]) .gallery__slot::slotted(*) {
+:host([variant="filmstrip"]) .gallery__slot::slotted(*) {
   flex: 0 0 auto;
   block-size: 100%;
   scroll-snap-align: start;
@@ -121,7 +121,7 @@
 /* Scroll-driven reveal animation */
 @supports (animation-timeline: view()) {
   @media (prefers-reduced-motion: no-preference) {
-    :host([filmstrip]) .gallery__slot::slotted(*) {
+    :host([variant="filmstrip"]) .gallery__slot::slotted(*) {
       animation: filmstrip-reveal linear both;
       animation-timeline: view(inline);
       animation-range: entry 0% entry 60%;

--- a/packages/ui/src/components/gallery/gallery.css
+++ b/packages/ui/src/components/gallery/gallery.css
@@ -38,8 +38,6 @@
   display: block;
   width: 100%;
   height: auto;
-  /* Make the image square */
-  aspect-ratio: 1;
   object-fit: cover;
   object-position: center;
 }
@@ -56,6 +54,27 @@
 }
 
 /* =============================================
+   GALLERY-IMAGE DEFAULT STYLES
+   (applied inside grantcodes-gallery-image shadow DOM via :host)
+   ============================================= */
+
+/* Default square crop. :host selector comes after .gallery__image img so
+   wins on equal specificity. Uses custom properties so filmstrip mode can
+   override them via inheritance from the parent gallery element. */
+:host .gallery__image img {
+  aspect-ratio: var(--_gallery-img-aspect-ratio, 1);
+  block-size: var(--_gallery-img-block-size, auto);
+  width: var(--_gallery-img-width, 100%);
+  height: var(--_gallery-img-height, auto);
+  max-inline-size: var(--_gallery-img-max-inline-size, unset);
+}
+
+:host .gallery__image {
+  block-size: var(--_gallery-image-block-size, auto);
+  width: var(--_gallery-image-width, 100%);
+}
+
+/* =============================================
    FILMSTRIP VARIANT
    ============================================= */
 
@@ -64,12 +83,13 @@
    without requiring JS attribute propagation, making the filmstrip work
    correctly with SSR-rendered content. */
 :host([filmstrip]) {
-  --_filmstrip-image-block-size: 100%;
-  --_filmstrip-image-width: fit-content;
-  --_filmstrip-img-block-size: 100%;
-  --_filmstrip-img-width: auto;
-  --_filmstrip-img-aspect-ratio: unset;
-  --_filmstrip-img-max-inline-size: none;
+  --_gallery-image-block-size: 100%;
+  --_gallery-image-width: fit-content;
+  --_gallery-img-aspect-ratio: auto;
+  --_gallery-img-block-size: 100%;
+  --_gallery-img-width: auto;
+  --_gallery-img-height: 100%;
+  --_gallery-img-max-inline-size: none;
 }
 
 :host([filmstrip]) .gallery {
@@ -118,35 +138,4 @@
     opacity: 1;
     scale: 1;
   }
-}
-
-/* Gallery-image filmstrip styles. These rules live in the gallery-image
-   shadow DOM context (:host = grantcodes-gallery-image). They read the
-   --_filmstrip-* custom properties inherited from the parent gallery
-   component, so they work without a filmstrip attribute on the image
-   element itself. The [filmstrip] attribute selector is kept as a
-   fallback for direct attribute usage. */
-:host .gallery__image {
-  block-size: var(--_filmstrip-image-block-size, auto);
-  width: var(--_filmstrip-image-width, 100%);
-}
-
-:host .gallery__image img {
-  block-size: var(--_filmstrip-img-block-size, auto);
-  width: var(--_filmstrip-img-width, 100%);
-  aspect-ratio: var(--_filmstrip-img-aspect-ratio, 1);
-  max-inline-size: var(--_filmstrip-img-max-inline-size, unset);
-}
-
-/* Attribute-based fallback (e.g. filmstrip set directly on the image) */
-:host([filmstrip]) .gallery__image {
-  block-size: 100%;
-  width: fit-content;
-}
-
-:host([filmstrip]) .gallery__image img {
-  block-size: 100%;
-  width: auto;
-  aspect-ratio: unset;
-  max-inline-size: none;
 }

--- a/packages/ui/src/components/gallery/gallery.stories.js
+++ b/packages/ui/src/components/gallery/gallery.stories.js
@@ -64,6 +64,7 @@ const filmstripImages = [
 	{ w: 160, h: 240 },
 	{ w: 360, h: 240 },
 	{ w: 180, h: 240 },
+	{ w: 160, h: 900 }, // tall portrait image
 	{ w: 420, h: 240 },
 	{ w: 160, h: 240 },
 	{ w: 380, h: 240 },

--- a/packages/ui/src/components/gallery/gallery.stories.js
+++ b/packages/ui/src/components/gallery/gallery.stories.js
@@ -77,7 +77,7 @@ const filmstripImages = [
 
 export const Filmstrip = {
 	args: {
-		filmstrip: true,
+		variant: "filmstrip",
 	},
 	render: (args) =>
 		template(

--- a/packages/ui/src/components/gallery/gallery.test.js
+++ b/packages/ui/src/components/gallery/gallery.test.js
@@ -66,18 +66,19 @@ describe("Gallery Component", () => {
 			cleanup(element);
 		});
 
-		it("should have filmstrip property default to false", async () => {
+		it("should have variant property default to 'default'", async () => {
 			element = await fixture("grantcodes-gallery");
-			assert.strictEqual(element.filmstrip, false, "filmstrip should default to false");
+			assert.strictEqual(element.variant, "default", "variant should default to 'default'");
 		});
 
-		it("should reflect filmstrip attribute when property is set", async () => {
+		it("should reflect variant attribute when property is set", async () => {
 			element = await fixture("grantcodes-gallery");
-			element.filmstrip = true;
+			element.variant = "filmstrip";
 			await element.updateComplete;
-			assert.ok(
-				element.hasAttribute("filmstrip"),
-				"filmstrip attribute should be reflected",
+			assert.strictEqual(
+				element.getAttribute("variant"),
+				"filmstrip",
+				"variant attribute should be reflected",
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

Closes #75.

- Fixes filmstrip images not being styled in SSR environments
- Refactors `filmstrip` boolean to `variant="filmstrip"` string prop (matching badge, notice, etc.)
- Removes `filmstrip` boolean from `grantcodes-gallery-image` (no longer needed)

## Problem

`_updateChildren()` propagated a `filmstrip` attribute to child elements via `slotchange`, which fires unreliably for SSR-rendered slotted content. Images kept `aspect-ratio: 1` and rendered as cropped squares.

## Fix

Replace JS attribute propagation entirely with inherited CSS custom properties:

- `grantcodes-gallery`'s `:host([variant="filmstrip"])` sets `--_gallery-*` custom properties
- These cascade to slotted `grantcodes-gallery-image` children via normal DOM inheritance
- `gallery-image` reads them via `var()` with fallbacks matching default (non-filmstrip) styles
- No JS, works from first render, SSR-safe

## Usage

```html
<!-- before -->
<grantcodes-gallery filmstrip>...</grantcodes-gallery>

<!-- after -->
<grantcodes-gallery variant="filmstrip">...</grantcodes-gallery>
```