### PR TITLE
fix(ui): improve hero and button colors across all themes

### DIFF
--- a/packages/style-dictionary/tokens/grantcodes/tier-2-usage/00-colors-background.json
+++ b/packages/style-dictionary/tokens/grantcodes/tier-2-usage/00-colors-background.json
@@ -26,10 +26,10 @@
 				"value": "light-dark({color.neutral.200}, {color.neutral.700})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.600}, {color.purple.700})"
+				"value": "light-dark({color.primary.700}, {color.primary.700})"
 			},
 			"primary-knockout-hover": {
-				"value": "light-dark({color.primary.500}, {color.purple.600})"
+				"value": "light-dark({color.primary.600}, {color.primary.600})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.100}, {color.secondary.900})"

--- a/packages/style-dictionary/tokens/grantcodes/tier-2-usage/00-colors-content.json
+++ b/packages/style-dictionary/tokens/grantcodes/tier-2-usage/00-colors-content.json
@@ -20,7 +20,7 @@
 				"value": "light-dark({color.primary.900}, {color.primary.100})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.100}, {color.primary.900})"
+				"value": "light-dark({color.neutral.white}, {color.neutral.white})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.600}, {color.secondary.400})"

--- a/packages/style-dictionary/tokens/grantcodes/tier-3-components/button.json
+++ b/packages/style-dictionary/tokens/grantcodes/tier-3-components/button.json
@@ -17,13 +17,13 @@
 			},
 			"content": {
 				"default": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary}"
 				},
 				"hover": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary-hover}"
 				},
 				"active": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary-hover}"
 				},
 				"disabled": {
 					"value": "{color.content.disabled}"
@@ -48,13 +48,13 @@
 			"color": {
 				"background": {
 					"default": {
-						"value": "{color.background.primary-knockout}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.background.primary-disabled}"
@@ -71,18 +71,18 @@
 						"value": "{color.neutral.white}"
 					},
 					"disabled": {
-						"value": "{color.content.default}"
+						"value": "{color.content.disabled}"
 					}
 				},
 				"border": {
 					"default": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.border.default}"

--- a/packages/style-dictionary/tokens/grantina/tier-2-usage/00-colors-content.json
+++ b/packages/style-dictionary/tokens/grantina/tier-2-usage/00-colors-content.json
@@ -20,7 +20,7 @@
 				"value": "light-dark({color.primary.900}, {color.primary.100})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.100}, {color.primary.900})"
+				"value": "light-dark({color.cream.100}, {color.cream.100})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.600}, {color.secondary.400})"

--- a/packages/style-dictionary/tokens/grantina/tier-3-components/button.json
+++ b/packages/style-dictionary/tokens/grantina/tier-3-components/button.json
@@ -17,13 +17,13 @@
 			},
 			"content": {
 				"default": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary}"
 				},
 				"hover": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary-hover}"
 				},
 				"active": {
-					"value": "{color.content.primary-knockout}"
+					"value": "{color.content.primary-hover}"
 				},
 				"disabled": {
 					"value": "{color.content.disabled}"
@@ -48,13 +48,13 @@
 			"color": {
 				"background": {
 					"default": {
-						"value": "{color.background.primary-knockout}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.background.primary-disabled}"
@@ -71,18 +71,18 @@
 						"value": "{color.neutral.white}"
 					},
 					"disabled": {
-						"value": "{color.content.default}"
+						"value": "{color.content.disabled}"
 					}
 				},
 				"border": {
 					"default": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.border.default}"

--- a/packages/style-dictionary/tokens/todomap/tier-2-usage/00-colors-background.json
+++ b/packages/style-dictionary/tokens/todomap/tier-2-usage/00-colors-background.json
@@ -26,10 +26,10 @@
 				"value": "light-dark({color.neutral.200}, {color.neutral.700})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.800}, {color.primary.500})"
+				"value": "light-dark({color.primary.800}, {color.primary.800})"
 			},
 			"primary-knockout-hover": {
-				"value": "light-dark({color.primary.700}, {color.primary.600})"
+				"value": "light-dark({color.primary.700}, {color.primary.700})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.100}, {color.secondary.900})"

--- a/packages/style-dictionary/tokens/todomap/tier-2-usage/00-colors-content.json
+++ b/packages/style-dictionary/tokens/todomap/tier-2-usage/00-colors-content.json
@@ -17,7 +17,7 @@
 				"value": "light-dark({color.primary.900}, {color.primary.100})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.100}, {color.primary.900})"
+				"value": "light-dark({color.neutral.white}, {color.neutral.white})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.600}, {color.secondary.400})"

--- a/packages/style-dictionary/tokens/todomap/tier-3-components/button.json
+++ b/packages/style-dictionary/tokens/todomap/tier-3-components/button.json
@@ -48,16 +48,16 @@
 			"color": {
 				"background": {
 					"default": {
-						"value": "{color.background.tertiary-knockout}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.background.tertiary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.background.tertiary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
-						"value": "{color.background.tertiary-disabled}"
+						"value": "{color.background.primary-disabled}"
 					}
 				},
 				"content": {
@@ -76,16 +76,16 @@
 				},
 				"border": {
 					"default": {
-						"value": "{color.border.tertiary}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.border.tertiary}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.border.tertiary}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
-						"value": "{color.border.disabled}"
+						"value": "{color.neutral.300}"
 					}
 				}
 			}

--- a/packages/style-dictionary/tokens/wireframe/tier-2-usage/00-colors-background.json
+++ b/packages/style-dictionary/tokens/wireframe/tier-2-usage/00-colors-background.json
@@ -26,10 +26,10 @@
 				"value": "light-dark({color.neutral.200}, {color.neutral.700})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.800}, {color.primary.500})"
+				"value": "light-dark({color.neutral.800}, {color.neutral.700})"
 			},
 			"primary-knockout-hover": {
-				"value": "light-dark({color.primary.700}, {color.primary.600})"
+				"value": "light-dark({color.neutral.700}, {color.neutral.600})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.100}, {color.secondary.900})"

--- a/packages/style-dictionary/tokens/wireframe/tier-2-usage/00-colors-content.json
+++ b/packages/style-dictionary/tokens/wireframe/tier-2-usage/00-colors-content.json
@@ -17,7 +17,7 @@
 				"value": "light-dark({color.primary.900}, {color.primary.100})"
 			},
 			"primary-knockout": {
-				"value": "light-dark({color.primary.100}, {color.primary.900})"
+				"value": "light-dark({color.neutral.white}, {color.neutral.white})"
 			},
 			"secondary": {
 				"value": "light-dark({color.secondary.600}, {color.secondary.400})"

--- a/packages/style-dictionary/tokens/wireframe/tier-3-components/button.json
+++ b/packages/style-dictionary/tokens/wireframe/tier-3-components/button.json
@@ -48,13 +48,13 @@
 			"color": {
 				"background": {
 					"default": {
-						"value": "{color.background.primary-knockout}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.background.primary-knockout-hover}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.background.primary-disabled}"
@@ -76,13 +76,13 @@
 				},
 				"border": {
 					"default": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.500}"
 					},
 					"hover": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"active": {
-						"value": "{color.border.primary}"
+						"value": "{color.primary.400}"
 					},
 					"disabled": {
 						"value": "{color.border.default}"

--- a/packages/ui/src/components/hero/hero.css
+++ b/packages/ui/src/components/hero/hero.css
@@ -15,7 +15,7 @@
 		align-items: center;
 		min-height: 50vh;
 		padding: var(--g-theme-spacing-2xl) var(--g-theme-spacing-md);
-		background: var(--g-theme-color-background-primary-knockout, #7c3aed);
+		background: linear-gradient(135deg, var(--g-theme-color-background-primary-knockout), var(--g-color-primary-900));
 	}
 
 	.hero__container {
@@ -34,13 +34,12 @@
 
 	.hero__title {
 		font: var(--g-typography-h1-font);
-		font-size: clamp(2rem, 5vw, 4rem);
-		color: var(--g-theme-color-content-primary-knockout, #ffffff);
+		color: var(--g-theme-color-content-primary-knockout);
 	}
 
 	.hero__text {
-		font: var(--g-theme-typography-body-lg);
-		color: var(--g-theme-color-content-primary-knockout, #ffffff);
+		font: var(--g-typography-body-lg);
+		color: var(--g-theme-color-content-primary-knockout);
 	}
 
 	:host([size="sm"]) .hero {


### PR DESCRIPTION
## Summary
- Fix hero gradient to use `background-primary-knockout` → `primary-900` so it's dark in both light/dark modes across all themes
- Fix button-primary to use `primary.500` solid color instead of knockout surface tokens, keeping buttons visually distinct from hero backgrounds
- Fix button borders to blend invisibly using `primary.500`/`primary.400`
- Fix `content-primary-knockout` to always be light text in both modes (no dark mode inversion)
- Fix `background-primary-knockout` to be consistently dark in both modes

## Changes by theme
- **grantcodes**: Purple gradient hero, solid purple-500 buttons, white knockout text
- **grantina**: Blue gradient hero, solid blue-500 buttons, cream knockout text
- **todomap**: Brand gradient hero, solid brand-500 buttons, white knockout text
- **wireframe**: Gray gradient hero, solid gray-500 buttons, white knockout text

## Test plan
- [ ] Verify hero gradient looks correct in both light and dark modes for all 4 themes
- [ ] Verify primary buttons are visible against the hero background
- [ ] Verify button borders are invisible (matching background)
- [ ] Verify knockout text is readable in both modes