### PR TITLE
fix(ui): replace #styles/ subpath imports with relative paths for SSR/Vite compat

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -129,6 +129,14 @@ Create the following files in `src/components/<component-name>/`:
 - `<component-name>.js` - Export and register custom element
 - `<component-name>.stories.js` - Storybook stories
 
+### Shared Styles
+
+Use relative paths (not `#styles/` subpath imports) for shared CSS files like focus-ring styles. This ensures components work in all environments including Vite dev mode and `<script>` tag imports:
+
+```javascript
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
+```
+
 ### 2. Register Custom Element
 
 In the `.js` file, register the custom element:

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,9 +7,6 @@
   "module": "src/main.js",
   "types": "src/types.d.ts",
   "author": "grantcodes",
-  "imports": {
-    "#styles/*": "./src/lib/styles/*"
-  },
   "exports": {
     ".": {
       "types": "./src/types.d.ts",

--- a/packages/ui/src/components/accordion/accordion.component.js
+++ b/packages/ui/src/components/accordion/accordion.component.js
@@ -1,6 +1,6 @@
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import accordionStyles from "./accordion.css" with { type: "css" };
 
 export class GrantCodesAccordion extends LitElement {

--- a/packages/ui/src/components/app-bar/app-bar.component.js
+++ b/packages/ui/src/components/app-bar/app-bar.component.js
@@ -1,7 +1,7 @@
 import { LitElement } from "lit";
 import { html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import appBarStyles from "./app-bar.css" with { type: "css" };
 
 export class GrantCodesAppBar extends LitElement {

--- a/packages/ui/src/components/app-bar/nav-link.component.js
+++ b/packages/ui/src/components/app-bar/nav-link.component.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import navLinkStyles from "./nav-link.css" with { type: "css" };
 
 export class GrantCodesNavLink extends LitElement {

--- a/packages/ui/src/components/breadcrumb/breadcrumb.component.js
+++ b/packages/ui/src/components/breadcrumb/breadcrumb.component.js
@@ -1,6 +1,6 @@
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import breadcrumbStyles from "./breadcrumb.css" with { type: "css" };
 
 export class GrantCodesBreadcrumb extends LitElement {

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import buttonStyles from "./button.css" with { type: "css" };
 
 export class GrantCodesButton extends LitElement {

--- a/packages/ui/src/components/sidebar/sidebar.component.js
+++ b/packages/ui/src/components/sidebar/sidebar.component.js
@@ -1,6 +1,6 @@
 import { html, LitElement } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import sidebarStyles from "./sidebar.css" with { type: "css" };
 
 export class GrantCodesSidebar extends LitElement {

--- a/packages/ui/src/components/tabs/internal/tabs-button.component.js
+++ b/packages/ui/src/components/tabs/internal/tabs-button.component.js
@@ -2,7 +2,7 @@ import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { GrantCodesTabsItem } from "./tabs-item.component.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../../lib/styles/focus-ring.css" with { type: "css" };
 import tabsStyles from "../tabs.css" with { type: "css" };
 
 export class GrantCodesTabsButton extends GrantCodesTabsItem {

--- a/packages/ui/src/components/tabs/tab.component.js
+++ b/packages/ui/src/components/tabs/tab.component.js
@@ -1,6 +1,6 @@
 import { GrantCodesTabsItem } from "./internal/tabs-item.component.js";
 import { html } from "lit/static-html.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import tabsStyles from "./tabs.css" with { type: "css" };
 
 export class GrantCodesTab extends GrantCodesTabsItem {

--- a/packages/ui/src/components/tabs/tabs.component.js
+++ b/packages/ui/src/components/tabs/tabs.component.js
@@ -1,6 +1,6 @@
 import { html, LitElement } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import tabsStyles from "./tabs.css" with { type: "css" };
 import { GrantCodesTab } from "./tab.component.js";
 import { GrantCodesTabsButton } from "./internal/tabs-button.component.js";

--- a/packages/ui/src/components/toast/toast.component.js
+++ b/packages/ui/src/components/toast/toast.component.js
@@ -1,7 +1,7 @@
 import { html, LitElement } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { classMap } from "lit/directives/class-map.js";
-import focusRingStyles from "#styles/focus-ring.css" with { type: "css" };
+import focusRingStyles from "../../lib/styles/focus-ring.css" with { type: "css" };
 import toastStyles from "./toast.css" with { type: "css" };
 import { GrantCodesIcon } from "../icon/icon.component.js";
 import { AlertCircle, Info, CheckCircle2, XCircle, X } from "../../icons.js";


### PR DESCRIPTION
## Summary

- Replace `#styles/focus-ring.css` subpath imports with relative paths (`../../lib/styles/focus-ring.css`) in all 10 components that use focus-ring styles
- Remove `#styles/*` from `package.json` imports field (no longer used internally; `./styles/focus-ring.css` export preserved for external consumers)
- Add shared styles guidance to `AGENTS.md` for new component creation

## Why

The `#styles/*` Node subpath import in `package.json` did not resolve in Vite dev mode when components were loaded via `<script>` tag (client-side-only pattern for SSR environments like astro-lit). This caused import failures for all components using `focus-ring.css`.

Relative imports work in every environment: Node SSR, Vite build, Vite dev mode, and browser `<script>` tag imports.

## Components changed

- `accordion/accordion.component.js`
- `app-bar/nav-link.component.js`
- `app-bar/app-bar.component.js`
- `button/button.component.js`
- `tabs/tabs.component.js`
- `tabs/tab.component.js`
- `tabs/internal/tabs-button.component.js`
- `toast/toast.component.js`
- `sidebar/sidebar.component.js`
- `breadcrumb/breadcrumb.component.js`

## Testing

- All 282 unit tests pass
- CEM validation errors are pre-existing (TabsItem/Tabs issues), unrelated to this change

Closes #53