### PR TITLE
chore(astro-blocks): prepare package for initial publish

### DIFF
--- a/packages/astro-blocks/README.md
+++ b/packages/astro-blocks/README.md
@@ -1,0 +1,126 @@
+# @grantcodes/astro-blocks
+
+Reusable Astro content blocks with theming support using `@grantcodes/ui` components.
+
+## Installation
+
+```bash
+npm install @grantcodes/astro-blocks
+```
+
+## Exports
+
+```javascript
+// Main exports (all blocks)
+import { Hero, Cards, Cta, Stats } from '@grantcodes/astro-blocks';
+
+// Individual blocks
+import Hero from '@grantcodes/astro-blocks/hero';
+import Cards from '@grantcodes/astro-blocks/cards';
+
+// Renderer for markdown content
+import BlockRenderer from '@grantcodes/astro-blocks/renderer';
+
+// Content schemas
+import { heroBlock, cardsBlock, blockSchema } from '@grantcodes/astro-blocks/schemas';
+```
+
+## Available Blocks
+
+- **Hero** - Full-width hero section with title, subtitle, image, and CTA
+- **Text** - Rich text content block
+- **Gallery** - Image gallery with optional captions
+- **Cards** - Grid of card components
+- **Accordion** - Collapsible accordion items
+- **Cta** - Call-to-action section with primary/secondary buttons
+- **FeatureList** - Grid of feature items with icons
+- **Stats** - Statistics display with labels and values
+- **LogoCloud** - Grid of partner/client logos
+- **Testimonials** - Customer testimonials with quotes and avatars
+- **Pricing** - Pricing tiers with features and CTAs
+- **Newsletter** - Email subscription form
+- **MediaText** - Side-by-side media and text block
+- **Map** - Embedded map with coordinates
+- **Countdown** - Countdown timer to a target date
+
+## Usage
+
+```astro
+---
+import { Hero, Cards } from '@grantcodes/astro-blocks';
+---
+
+<Hero
+  title="Welcome"
+  subtitle="Build sustainable websites"
+  button="Get Started"
+  href="/docs"
+/>
+
+<Cards
+  cards={[
+    { title: 'Feature 1', description: 'Description here' },
+    { title: 'Feature 2', description: 'Description here' },
+  ]}
+/>
+```
+
+## Content Schemas
+
+All blocks export Zod schemas that can be used with Astro Content Collections:
+
+```astro
+---
+import { z, defineCollection } from 'astro:content';
+import { heroBlock, cardsBlock } from '@grantcodes/astro-blocks/schemas';
+
+const blocks = defineCollection({
+  type: 'data',
+  schema: z.discriminatedUnion('type', [
+    heroBlock,
+    cardsBlock,
+    // ... other blocks
+  ]),
+});
+---
+```
+
+## Block Renderer
+
+Use the renderer to dynamically render blocks from data:
+
+```astro
+---
+import BlockRenderer from '@grantcodes/astro-blocks/renderer';
+import { blockSchema } from '@grantcodes/astro-blocks/schemas';
+
+const { data } = Astro.props;
+---
+
+{data.blocks.map((block) => (
+  <BlockRenderer block={block} />
+))}
+```
+
+## Theming
+
+Blocks use `@grantcodes/ui` components which respect the theme. Import a theme in your layout:
+
+```astro
+import '@grantcodes/ui/styles/themes/grantcodes.css';
+```
+
+Available themes:
+- `grantcodes.css` - Default theme
+- `wireframe.css` - Minimal theme
+- `todomap.css` - Alternative theme
+
+## Dependencies
+
+- `astro` (peer dependency)
+- `@grantcodes/ui` - UI components
+- `@grantcodes/style-dictionary` - Design tokens
+
+## License
+
+MIT

--- a/packages/astro-blocks/package.json
+++ b/packages/astro-blocks/package.json
@@ -3,11 +3,42 @@
   "version": "0.0.1",
   "type": "module",
   "description": "Reusable Astro content blocks with theming support",
+  "license": "MIT",
+  "author": "grantcodes",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/grantcodes/ui.git",
+    "directory": "packages/astro-blocks"
+  },
+  "bugs": {
+    "url": "https://github.com/grantcodes/ui/issues"
+  },
+  "homepage": "https://github.com/grantcodes/ui/tree/main/packages/astro-blocks#readme",
   "exports": {
     ".": "./src/index.ts",
+    "./accordion": "./src/accordion.astro",
+    "./cards": "./src/cards.astro",
+    "./countdown": "./src/countdown.astro",
+    "./cta": "./src/cta.astro",
+    "./feature-list": "./src/feature-list.astro",
+    "./gallery": "./src/gallery.astro",
+    "./hero": "./src/hero.astro",
+    "./logo-cloud": "./src/logo-cloud.astro",
+    "./map": "./src/map.astro",
+    "./media-text": "./src/media-text.astro",
+    "./newsletter": "./src/newsletter.astro",
+    "./pricing": "./src/pricing.astro",
     "./renderer": "./src/renderer.astro",
-    "./schemas": "./src/schemas/index.ts"
+    "./schemas": "./src/schemas/index.ts",
+    "./stats": "./src/stats.astro",
+    "./testimonials": "./src/testimonials.astro",
+    "./text": "./src/text.astro"
   },
+  "files": [
+    "src/**/*",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "echo 'No build step required'",
     "fix": "echo 'No lint configured'",
@@ -23,8 +54,8 @@
     "astro": "^5.0.0"
   },
   "dependencies": {
-    "@grantcodes/style-dictionary": "workspace:*",
-    "@grantcodes/ui": "workspace:*",
+    "@grantcodes/style-dictionary": "workspace:^",
+    "@grantcodes/ui": "workspace:^",
     "marked": "^17.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,10 +67,10 @@ importers:
   packages/astro-blocks:
     dependencies:
       '@grantcodes/style-dictionary':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../style-dictionary
       '@grantcodes/ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ui
       marked:
         specifier: ^17.0.4

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,12 +2,15 @@
 	"release-type": "node",
 	"include-v-in-tags": false,
 	"bootstrap-sha": "9490cfce72bb08e3ff001af5e3a08b2a1b760884",
-	"packages": {
+  "packages": {
 		"packages/ui": {
 			"package-name": "@grantcodes/ui"
 		},
 		"packages/style-dictionary": {
 			"package-name": "@grantcodes/style-dictionary"
+		},
+		"packages/astro-blocks": {
+			"package-name": "@grantcodes/astro-blocks"
 		}
 	}
 }


### PR DESCRIPTION
Prepares the `@grantcodes/astro-blocks` package for its first npm publish.

**Changes:**

- **package.json**
  - Added `"files": ["src/**/*", "README.md", "CHANGELOG.md"]` so the published tarball includes all source code
  - Added missing export entries for all block components: `cta`, `feature-list`, `logo-cloud`, `media-text`, `newsletter`, `pricing`, `stats`, `testimonials`
  - Switched `workspace:*` dependencies to `workspace:^` so pnpm resolves them to semver ranges on publish
  - Added `license`, `author`, `repository`, `bugs`, and `homepage` metadata

- **README.md** (new)
  - Full usage guide with installation, imports, block list, schema usage, renderer docs, and theming info

- **release-please-config.json**
  - Registered `packages/astro-blocks` for automated releases

Closes #prepare-publish