### PR TITLE
fix(form-field): reflect label for SSR hydration and replace JS inline detection with CSS :has()

### DIFF
--- a/packages/ui/src/components/form-field/form-field.component.js
+++ b/packages/ui/src/components/form-field/form-field.component.js
@@ -1,7 +1,6 @@
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
 import formFieldStyles from "./form-field.css" with { type: "css" };
-import { classMap } from "lit/directives/class-map.js";
 import { generateId } from "../../lib/generate-id.js";
 
 export class GrantCodesFormField extends LitElement {
@@ -9,7 +8,7 @@ export class GrantCodesFormField extends LitElement {
 	static styles = [formFieldStyles];
 
 	static properties = {
-		label: { type: String },
+		label: { type: String, reflect: true },
 		error: { type: String },
 		help: { type: String },
 	};
@@ -21,7 +20,6 @@ export class GrantCodesFormField extends LitElement {
 		this.error = undefined;
 		this.help = undefined;
 
-		this.inlineInput = false;
 		this.groupInput = false;
 
 		/** @type {NodeListOf<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>} */
@@ -77,10 +75,6 @@ export class GrantCodesFormField extends LitElement {
 		input.id = this.id;
 		input.setAttribute("aria-describedby", this.ariaDescribedBy);
 
-		if (input.type === "checkbox" || input.type === "radio") {
-			this.inlineInput = true;
-			this.requestUpdate();
-		}
 	}
 
 	handleLabelClick() {
@@ -130,14 +124,9 @@ export class GrantCodesFormField extends LitElement {
 	}
 
 	render() {
-		const classes = classMap({
-			"form-field": true,
-			"form-field--inline": this.inlineInput,
-		});
-
 		if (this.groupInput) {
 			return html`
-      <fieldset class=${classes}>
+      <fieldset class="form-field">
         <legend class="form-field__label">${this.label}</legend>
         <slot></slot>
         ${this.errorTemplate()}
@@ -146,7 +135,7 @@ export class GrantCodesFormField extends LitElement {
 		}
 
 		return html`
-      <div class=${classes}>
+      <div class="form-field">
         <label>
           <span class="form-field__label" @click=${this.handleLabelClick}
             >${this.label}</span

--- a/packages/ui/src/components/form-field/form-field.css
+++ b/packages/ui/src/components/form-field/form-field.css
@@ -20,7 +20,7 @@
 	gap: inherit;
 }
 
-.form-field--inline label {
+:host(:has(> input[type="checkbox"], > input[type="radio"])) .form-field label {
 	flex-direction: row-reverse;
 	align-items: center;
 	justify-content: flex-end;

--- a/packages/ui/src/components/form-field/form-field.test.js
+++ b/packages/ui/src/components/form-field/form-field.test.js
@@ -30,6 +30,18 @@ describe("Form Field Component", () => {
 		);
 	});
 
+	it("should reflect label text for SSR client upgrade", async () => {
+		element = await fixture("grantcodes-form-field", {
+			label: "Username",
+		});
+
+		assert.strictEqual(
+			element.getAttribute("label"),
+			"Username",
+			"Label should be serialized to an attribute for client upgrade",
+		);
+	});
+
 	it("should display error message when error is set", async () => {
 		element = await fixture("grantcodes-form-field", {
 			label: "Email",


### PR DESCRIPTION
## Summary

- Reflected `label` property to attribute so Astro Lit SSR serializes it for client upgrade, fixing radio/checkbox labels disappearing after `client:load`.
- Replaced JavaScript checkbox/radio inline layout detection with CSS `:host(:has(> input[type="checkbox"], > input[type="radio"]))`, removing the need for reactive `inlineInput` state and `requestUpdate()` calls.
- Added regression test for label attribute reflection.

## Changes

- `packages/ui/src/components/form-field/form-field.component.js`
  - Added `reflect: true` to `label` property
  - Removed `inlineInput` reactive property and related detection in `firstUpdated()`
  - Removed `classMap` import and simplified render template
- `packages/ui/src/components/form-field/form-field.css`
  - Replaced `.form-field--inline label` with `:host(:has(> input[type="checkbox"], > input[type="radio"])) .form-field label`
- `packages/ui/src/components/form-field/form-field.test.js`
  - Added test verifying label attribute reflection for SSR client upgrade

## Verification

- User confirmed RSVP page radio labels remain visible after `client:load` hydration.
- All 291 unit tests pass.