### PR TITLE
Form-Associated Custom Element (FACE) support for grantcodes-button

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,0 +1,2 @@
+# Playwright
+test-results/

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -65,6 +65,30 @@ export class GrantCodesButton extends LitElement {
 		// type === "button" or any other value: no form action (default no-op)
 	}
 
+	formDisabledCallback(disabled) {
+		// Called by the browser when the button or an ancestor fieldset becomes disabled.
+		// The internal <button>'s ?disabled binding handles visual/ARIA state.
+		// This callback ensures the host-level disabled state is synced.
+		// No additional action needed — the existing disabled property + ?disabled binding
+		// + _handleFormClick guard (checks this.disabled) already handle this.
+	}
+
+	formResetCallback() {
+		// Called by the browser when the associated form is reset.
+		// Reset the value to an empty string (default state).
+		// If a future version tracks an initial value, restore it here.
+		this.value = "";
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		// Ensure initial form value is set after first render.
+		// updated() handles subsequent changes; this handles the initial state.
+		if (this.internals) {
+			this.internals.setFormValue(this.name ? this.value : null);
+		}
+	}
+
 	// The render() method is called any time reactive properties change.
 	// Return HTML in a string template literal tagged with the `html`
 	// tag function to describe the component's internal DOM.

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -49,6 +49,22 @@ export class GrantCodesButton extends LitElement {
 		}
 	}
 
+	_handleFormClick(e) {
+		// Only handle form actions when we have internals and are inside a form
+		if (!this.internals || !this.internals.form || this.disabled) {
+			return;
+		}
+
+		if (this.type === "submit") {
+			e.preventDefault();
+			this.internals.form.requestSubmit(this);
+		} else if (this.type === "reset") {
+			e.preventDefault();
+			this.internals.form.reset();
+		}
+		// type === "button" or any other value: no form action (default no-op)
+	}
+
 	// The render() method is called any time reactive properties change.
 	// Return HTML in a string template literal tagged with the `html`
 	// tag function to describe the component's internal DOM.
@@ -77,6 +93,7 @@ export class GrantCodesButton extends LitElement {
 				name=${this.name ?? ""}
 				value=${this.value ?? ""}
 				?disabled=${this.disabled}
+				@click=${this._handleFormClick}
 			>
 				<span><slot></slot></span>
 			</button>

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -10,12 +10,15 @@ export class GrantCodesButton extends LitElement {
 	// via CSS custom properties.
 	static styles = [focusRingStyles, buttonStyles];
 
+	static formAssociated = true;
+
 	static properties = {
 		href: { type: String },
 		type: { type: String },
 		name: { type: String },
 		value: { type: String },
 		disabled: { type: Boolean, reflect: true },
+		form: { type: String, reflect: true },
 	};
 
 	constructor() {
@@ -25,7 +28,25 @@ export class GrantCodesButton extends LitElement {
 		this.type = "button";
 		this.name = "";
 		this.value = "";
+		this.form = "";
+
+		// Attach ElementInternals for form participation.
+		// try/catch because happy-dom (DOM-shim test env) may not support attachInternals()
+		try {
+			this.internals = this.attachInternals();
+		} catch (e) {
+			this.internals = null;
+		}
 		this.disabled = false;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (this.internals) {
+			if (changedProperties.has("name") || changedProperties.has("value")) {
+				this.internals.setFormValue(this.name ? this.value : null);
+			}
+		}
 	}
 
 	// The render() method is called any time reactive properties change.

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -28,7 +28,7 @@ export class GrantCodesButton extends LitElement {
 		this.type = "button";
 		this.name = "";
 		this.value = "";
-		this.form = "";
+		// Do NOT set form="" — an empty form attribute overrides ancestor form association
 
 		// Attach ElementInternals for form participation.
 		// try/catch because happy-dom (DOM-shim test env) may not support attachInternals()
@@ -49,17 +49,25 @@ export class GrantCodesButton extends LitElement {
 		}
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener("click", this._handleFormClick);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener("click", this._handleFormClick);
+	}
+
 	_handleFormClick(e) {
+		// href mode renders a link — do not intercept form actions
+		if (this.href) return;
 		// Only handle form actions when we have internals and are inside a form
-		if (!this.internals || !this.internals.form || this.disabled) {
-			return;
-		}
+		if (!this.internals || !this.internals.form || this.disabled) return;
 
 		if (this.type === "submit") {
-			e.preventDefault();
-			this.internals.form.requestSubmit(this);
+			this.internals.form.requestSubmit();
 		} else if (this.type === "reset") {
-			e.preventDefault();
 			this.internals.form.reset();
 		}
 		// type === "button" or any other value: no form action (default no-op)
@@ -113,11 +121,10 @@ export class GrantCodesButton extends LitElement {
 		return html`
 			<button
 				class="button focus-ring"
-				type=${this.type}
+				type="button"
 				name=${this.name ?? ""}
 				value=${this.value ?? ""}
 				?disabled=${this.disabled}
-				@click=${this._handleFormClick}
 			>
 				<span><slot></slot></span>
 			</button>

--- a/packages/ui/src/components/button/button.component.js
+++ b/packages/ui/src/components/button/button.component.js
@@ -29,6 +29,7 @@ export class GrantCodesButton extends LitElement {
 		this.name = "";
 		this.value = "";
 		// Do NOT set form="" — an empty form attribute overrides ancestor form association
+		this._fieldsetDisabled = false;
 
 		// Attach ElementInternals for form participation.
 		// try/catch because happy-dom (DOM-shim test env) may not support attachInternals()
@@ -65,20 +66,18 @@ export class GrantCodesButton extends LitElement {
 		// Only handle form actions when we have internals and are inside a form
 		if (!this.internals || !this.internals.form || this.disabled) return;
 
-		if (this.type === "submit") {
+		const t = this.type.toLowerCase();
+		if (t === "submit") {
 			this.internals.form.requestSubmit();
-		} else if (this.type === "reset") {
+		} else if (t === "reset") {
 			this.internals.form.reset();
 		}
 		// type === "button" or any other value: no form action (default no-op)
 	}
 
 	formDisabledCallback(disabled) {
-		// Called by the browser when the button or an ancestor fieldset becomes disabled.
-		// The internal <button>'s ?disabled binding handles visual/ARIA state.
-		// This callback ensures the host-level disabled state is synced.
-		// No additional action needed — the existing disabled property + ?disabled binding
-		// + _handleFormClick guard (checks this.disabled) already handle this.
+		this._fieldsetDisabled = disabled;
+		this.requestUpdate();
 	}
 
 	formResetCallback() {
@@ -86,15 +85,6 @@ export class GrantCodesButton extends LitElement {
 		// Reset the value to an empty string (default state).
 		// If a future version tracks an initial value, restore it here.
 		this.value = "";
-	}
-
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-		// Ensure initial form value is set after first render.
-		// updated() handles subsequent changes; this handles the initial state.
-		if (this.internals) {
-			this.internals.setFormValue(this.name ? this.value : null);
-		}
 	}
 
 	// The render() method is called any time reactive properties change.
@@ -111,7 +101,7 @@ export class GrantCodesButton extends LitElement {
 				<a
 					class="button focus-ring"
 					href=${this.href}
-					?disabled=${this.disabled}
+					?disabled=${this.disabled || this._fieldsetDisabled}
 				>
 					<span><slot></slot></span>
 				</a>
@@ -124,7 +114,7 @@ export class GrantCodesButton extends LitElement {
 				type="button"
 				name=${this.name ?? ""}
 				value=${this.value ?? ""}
-				?disabled=${this.disabled}
+				?disabled=${this.disabled || this._fieldsetDisabled}
 			>
 				<span><slot></slot></span>
 			</button>

--- a/packages/ui/src/components/button/button.test.js
+++ b/packages/ui/src/components/button/button.test.js
@@ -177,4 +177,21 @@ describe("Form Context", () => {
 			"Internal button should have disabled attribute",
 		);
 	});
+
+	it("should render as link not button when href is set", async () => {
+		element = await fixture("grantcodes-button", {
+			href: "https://example.com",
+		});
+		await element.updateComplete;
+
+		const button = element.shadowRoot.querySelector("button");
+		const link = element.shadowRoot.querySelector("a");
+		assert.strictEqual(button, null, "Should not render a button when href is set");
+		assert.ok(link, "Should render a link when href is set");
+		const href = link.getAttribute("href");
+		assert.ok(
+			href === "https://example.com" || href.includes("example.com"),
+			"Link href should contain example.com",
+		);
+	});
 });

--- a/packages/ui/src/components/button/button.test.js
+++ b/packages/ui/src/components/button/button.test.js
@@ -1,6 +1,7 @@
 import { describe, it, afterEach } from "node:test";
 import { strict as assert } from "node:assert";
 import { fixture, cleanup, click } from "../../test-utils/index.js";
+import { GrantCodesButton } from "./button.component.js";
 import "./button.js";
 
 describe("Button Component", () => {
@@ -193,5 +194,86 @@ describe("Form Context", () => {
 			href === "https://example.com" || href.includes("example.com"),
 			"Link href should contain example.com",
 		);
+	});
+});
+
+describe("FACE Infrastructure", () => {
+	let element;
+
+	afterEach(() => {
+		cleanup(element);
+	});
+
+	it("should declare formAssociated as true", () => {
+		assert.strictEqual(
+			GrantCodesButton.formAssociated,
+			true,
+			"GrantCodesButton.formAssociated should be true",
+		);
+	});
+
+	it("should have internals property after construction", async () => {
+		element = await fixture("grantcodes-button");
+		// internals may be null in happy-dom (attachInternals throws), but the
+		// property must exist — it was assigned in the constructor's try/catch.
+		assert.ok(
+			"internals" in element,
+			"Element should have internals property",
+		);
+		// In happy-dom: element.internals === null (expected — DOM shim limitation)
+		// In real browser: element.internals instanceof ElementInternals
+	});
+
+	it("should reflect form attribute when set as property", async () => {
+		element = await fixture("grantcodes-button", {
+			form: "myForm",
+		});
+		await element.updateComplete;
+
+		assert.strictEqual(
+			element.getAttribute("form"),
+			"myForm",
+			"form attribute should reflect property value 'myForm'",
+		);
+		assert.strictEqual(
+			element.form,
+			"myForm",
+			"element.form property should be 'myForm'",
+		);
+	});
+
+	it("should not have form attribute by default", async () => {
+		element = await fixture("grantcodes-button");
+		await element.updateComplete;
+
+		const formAttr = element.getAttribute("form");
+		assert.ok(
+			formAttr === null || formAttr === "",
+			"form attribute should be null or empty by default",
+		);
+	});
+
+	it("should still reflect type='submit' on internal button after FACE changes", async () => {
+		element = await fixture("grantcodes-button", { type: "submit" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Internal button should exist");
+		assert.strictEqual(
+			button.type,
+			"submit",
+			"Internal button type should still be 'submit' after FACE wiring",
+		);
+	});
+
+	it("should still render as link not button when href is set", async () => {
+		element = await fixture("grantcodes-button", {
+			href: "https://example.com",
+		});
+		await element.updateComplete;
+
+		const button = element.shadowRoot.querySelector("button");
+		const link = element.shadowRoot.querySelector("a");
+		assert.strictEqual(button, null, "Should not render a button when href is set");
+		assert.ok(link, "Should render a link when href is set");
 	});
 });

--- a/packages/ui/src/components/button/button.test.js
+++ b/packages/ui/src/components/button/button.test.js
@@ -100,3 +100,81 @@ describe("Button Component", () => {
 		assert.ok(slot, "Slot should exist");
 	});
 });
+
+describe("Form Context", () => {
+	let element;
+	let form;
+
+	afterEach(() => {
+		cleanup(element);
+		cleanup(form);
+	});
+
+	it("should render button inside a form element", async () => {
+		form = document.createElement("form");
+		document.body.appendChild(form);
+
+		element = document.createElement("grantcodes-button");
+		form.appendChild(element);
+		await element.updateComplete;
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Button should exist in shadow DOM when inside form");
+		const link = element.shadowRoot.querySelector("a");
+		assert.strictEqual(link, null, "Should not render a link when inside form");
+	});
+
+	it("should use type='button' as default on internal button", async () => {
+		element = await fixture("grantcodes-button");
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(button.type, "button", "Default type should be 'button'");
+	});
+
+	it("should reflect type='submit' on internal button", async () => {
+		element = await fixture("grantcodes-button", { type: "submit" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(button.type, "submit", "Internal button type should be 'submit'");
+	});
+
+	it("should reflect type='reset' on internal button", async () => {
+		element = await fixture("grantcodes-button", { type: "reset" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(button.type, "reset", "Internal button type should be 'reset'");
+	});
+
+	it("should reflect name property on internal button", async () => {
+		element = await fixture("grantcodes-button", { name: "myButton" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(
+			button.getAttribute("name"),
+			"myButton",
+			"Internal button name attribute should be 'myButton'",
+		);
+	});
+
+	it("should reflect value property on internal button", async () => {
+		element = await fixture("grantcodes-button", { value: "send" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(
+			button.getAttribute("value"),
+			"send",
+			"Internal button value attribute should be 'send'",
+		);
+	});
+
+	it("should reflect disabled property on internal button", async () => {
+		element = await fixture("grantcodes-button", { disabled: true });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.strictEqual(button.disabled, true, "Internal button should be disabled");
+		assert.ok(
+			button.hasAttribute("disabled"),
+			"Internal button should have disabled attribute",
+		);
+	});
+});

--- a/packages/ui/src/components/button/button.test.js
+++ b/packages/ui/src/components/button/button.test.js
@@ -85,8 +85,11 @@ describe("Button Component", () => {
 
 		for (const type of types) {
 			const testElement = await fixture("grantcodes-button", { type });
+			// Internal button is always type="button" — form behavior is handled
+			// by the host element via FACE (requestSubmit/reset on ElementInternals)
 			const button = testElement.shadowRoot.querySelector("button");
-			assert.strictEqual(button.type, type, `Button type should be ${type}`);
+			assert.strictEqual(button.type, "button", `Internal button should always be type="button"`);
+			assert.strictEqual(testElement.type, type, `Host type property should be ${type}`);
 			cleanup(testElement);
 		}
 	});
@@ -132,18 +135,22 @@ describe("Form Context", () => {
 		assert.strictEqual(button.type, "button", "Default type should be 'button'");
 	});
 
-	it("should reflect type='submit' on internal button", async () => {
+	it("should keep internal button as type='button' when host type is submit", async () => {
 		element = await fixture("grantcodes-button", { type: "submit" });
 
 		const button = element.shadowRoot.querySelector("button");
-		assert.strictEqual(button.type, "submit", "Internal button type should be 'submit'");
+		// Internal button is always type="button" — FACE handles submit via requestSubmit()
+		assert.strictEqual(button.type, "button", "Internal button should be type='button'");
+		assert.strictEqual(element.type, "submit", "Host type property should be 'submit'");
 	});
 
-	it("should reflect type='reset' on internal button", async () => {
+	it("should keep internal button as type='button' when host type is reset", async () => {
 		element = await fixture("grantcodes-button", { type: "reset" });
 
 		const button = element.shadowRoot.querySelector("button");
-		assert.strictEqual(button.type, "reset", "Internal button type should be 'reset'");
+		// Internal button is always type="button" — FACE handles reset via form.reset()
+		assert.strictEqual(button.type, "button", "Internal button should be type='button'");
+		assert.strictEqual(element.type, "reset", "Host type property should be 'reset'");
 	});
 
 	it("should reflect name property on internal button", async () => {
@@ -253,15 +260,15 @@ describe("FACE Infrastructure", () => {
 		);
 	});
 
-	it("should still reflect type='submit' on internal button after FACE changes", async () => {
+	it("should use type='button' on internal button after FACE changes", async () => {
 		element = await fixture("grantcodes-button", { type: "submit" });
 
 		const button = element.shadowRoot.querySelector("button");
 		assert.ok(button, "Internal button should exist");
 		assert.strictEqual(
 			button.type,
-			"submit",
-			"Internal button type should still be 'submit' after FACE wiring",
+			"button",
+			"Internal button should be type='button' — FACE handles submit via requestSubmit()",
 		);
 	});
 
@@ -316,15 +323,15 @@ describe("FACE Infrastructure", () => {
 		assert.strictEqual(threw, false, "Clicking disabled button should not throw");
 	});
 
-	it("should have type='reset' on internal button when type property is reset", async () => {
+	it("should keep internal button as type='button' when host type is reset", async () => {
 		element = await fixture("grantcodes-button", { type: "reset" });
 
 		const button = element.shadowRoot.querySelector("button");
 		assert.ok(button, "Internal button should exist");
 		assert.strictEqual(
 			button.type,
-			"reset",
-			"Internal button type should be 'reset'",
+			"button",
+			"Internal button should be type='button' — FACE handles reset via form.reset()",
 		);
 	});
 

--- a/packages/ui/src/components/button/button.test.js
+++ b/packages/ui/src/components/button/button.test.js
@@ -276,4 +276,67 @@ describe("FACE Infrastructure", () => {
 		assert.strictEqual(button, null, "Should not render a button when href is set");
 		assert.ok(link, "Should render a link when href is set");
 	});
+
+	it("should have disabled attribute on internal button when disabled", async () => {
+		element = await fixture("grantcodes-button", {
+			disabled: true,
+		});
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Internal button should exist");
+		assert.strictEqual(
+			button.disabled,
+			true,
+			"Internal button should be disabled when element.disabled is true",
+		);
+		assert.ok(
+			button.hasAttribute("disabled"),
+			"Internal button should have disabled attribute",
+		);
+	});
+
+	it("should not throw when clicking internal button while disabled", async () => {
+		element = await fixture("grantcodes-button", {
+			disabled: true,
+			type: "submit",
+		});
+		await element.updateComplete;
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Internal button should exist");
+
+		// _handleFormClick should early-return when this.disabled is true.
+		// Verify clicking does not throw (no internals.form access attempted).
+		let threw = false;
+		try {
+			button.click();
+		} catch (e) {
+			threw = true;
+		}
+		assert.strictEqual(threw, false, "Clicking disabled button should not throw");
+	});
+
+	it("should have type='reset' on internal button when type property is reset", async () => {
+		element = await fixture("grantcodes-button", { type: "reset" });
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Internal button should exist");
+		assert.strictEqual(
+			button.type,
+			"reset",
+			"Internal button type should be 'reset'",
+		);
+	});
+
+	it("should have type='button' as default on internal button", async () => {
+		element = await fixture("grantcodes-button");
+
+		const button = element.shadowRoot.querySelector("button");
+		assert.ok(button, "Internal button should exist");
+		assert.strictEqual(
+			button.type,
+			"button",
+			"Default internal button type should be 'button'",
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- Makes `grantcodes-button` a form-associated custom element using ElementInternals
- Adds 34 tests (26 DOM-shim + 8 Playwright e2e) covering submit, reset, FormData, disabled/fieldset, external form association, and href mode
- Simplifies FACE implementation per code review

## Changes

### Phase 21: DOM-shim form contract tests
- 8 new test cases verifying property-to-DOM contract (type, name, value, disabled, href link mode)
- All assertions at DOM-shim level

### Phase 22: FACE Implementation
- `static formAssociated = true` + `attachInternals()` wiring
- Host-level click handler routes submit/reset through `internals.form.requestSubmit()` / `reset()`
- `setFormValue()` integration for `name=value` in FormData
- `formResetCallback`, `formDisabledCallback` lifecycle callbacks
- `form` property for external form association (e.g. `form="other-form"`)
- Disabled and href-mode guards suppress form behavior

### Phase 22: Tests
- 10 DOM-shim FACE contract tests
- Playwright e2e test suite (8 tests) + test fixture page
- 6 bugs discovered and fixed during e2e testing (type="button" hardening, host click listener, form="" init removal, requestSubmit fix)

### Post-review simplifications
- Removed redundant `firstUpdated` method (duplicate `setFormValue` call)
- Fixed `formDisabledCallback` to actually track fieldset-disabled state
- Case-insensitive type comparison (`type="Submit"` now works)

## Files Changed
- `packages/ui/src/components/button/button.component.js` — FACE implementation
- `packages/ui/src/components/button/button.test.js` — 26 unit tests (+18 new)
- `packages/ui/src/components/button/button.e2e.spec.js` — 8 Playwright e2e tests
- `packages/ui/playwright.config.js` — Playwright configuration
- `packages/ui/test-fixtures/button-form.html` — e2e test fixture