### PR TITLE
chore: remove astro-blocks release wiring and publish @grantcodes/astro

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -55,9 +55,9 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Publish @grantcodes/astro-blocks
-              if: ${{ steps.release.outputs['packages/astro-blocks--release_created'] }}
-              working-directory: packages/astro-blocks
+            - name: Publish @grantcodes/astro
+              if: ${{ steps.release.outputs['packages/astro--release_created'] }}
+              working-directory: packages/astro
               run: pnpm publish --access public --no-git-checks
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
 	"packages/ui": "2.12.1",
 	"packages/style-dictionary": "1.6.0",
-	"packages/astro-blocks": "1.4.0"
+	"packages/astro": "0.0.1"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Monorepo for UI packages using pnpm workspaces and Turbo.
 
 - `@grantcodes/ui` - Web components library built with Lit - [See AGENTS.md](packages/ui/AGENTS.md)
 - `@grantcodes/style-dictionary` - Design tokens and theming - [See AGENTS.md](packages/style-dictionary/AGENTS.md)
-- `@grantcodes/astro-blocks` - Reusable Astro content blocks - [See AGENTS.md](packages/astro-blocks/AGENTS.md)
+- `@grantcodes/astro` - Astro integration (includes reusable Astro content blocks)
 - `@grantcodes/astro-starter` - Personal website - [See AGENTS.md](apps/astro/AGENTS.md)
 
 ## Commands

--- a/apps/astro/AGENTS.md
+++ b/apps/astro/AGENTS.md
@@ -7,7 +7,7 @@ Personal website built with Astro, using `@grantcodes/ui` components and `@grant
 - **Astro** - Static site generator
 - **Starlight** - Documentation theme
 - **@grantcodes/ui** - Web components library
-- **@grantcodes/astro-blocks** - Reusable content blocks
+- **@grantcodes/astro** - Astro integration with reusable content blocks
 
 ## Project Structure
 
@@ -46,5 +46,4 @@ pnpm build
 
 - `@grantcodes/ui` - Web components
 - `@grantcodes/style-dictionary` - Design tokens
-- `@grantcodes/astro-blocks` - Content blocks
-- `@grantcodes/astro-og-images` - Open Graph images
+- `@grantcodes/astro` - Integration + content blocks + Open Graph images

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "fix:style-dictionary": "pnpm --filter @grantcodes/style-dictionary fix",
     "clean": "turbo run clean && rm -rf node_modules",
     "clean:all": "turbo run clean && rm -rf node_modules packages/*/node_modules apps/*/node_modules",
-    "storybook": "pnpm --filter @grantcodes/ui,@grantcodes/astro-blocks storybook",
-    "dev:astro-blocks": "pnpm --filter @grantcodes/astro-blocks dev",
+    "storybook": "pnpm --filter @grantcodes/ui storybook",
     "generate": "pnpm --filter @grantcodes/ui generate"
   },
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -30,8 +30,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@grantcodes/style-dictionary": "workspace:^",
-    "@grantcodes/ui": "workspace:^",
+    "@grantcodes/style-dictionary": "^1.5.1",
+    "@grantcodes/ui": "^2.12.0",
     "@resvg/resvg-js": "^2.6.2",
     "@lit-labs/ssr": "^3.3.1",
     "@lit-labs/ssr-client": "^1.1.7",

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -21,7 +21,7 @@ export default function integration(options?: UiOptions): AstroIntegration {
 
 	return {
 		name: "@grantcodes/astro",
-		hooks: {
+			hooks: {
 			"astro:config:setup": ({ addRenderer, updateConfig, injectScript, config }) => {
 				if (options?.theme) {
 					injectScript("page-ssr", `import '${theme.stylesheetImport}';`);
@@ -38,10 +38,10 @@ export default function integration(options?: UiOptions): AstroIntegration {
 				const noExternal = config.vite?.resolve?.noExternal;
 				if (
 					Array.isArray(noExternal) &&
-					(noExternal.includes("@grantcodes/ui") || noExternal.includes("@grantcodes/astro-blocks"))
+					noExternal.includes("@grantcodes/ui")
 				) {
 					console.warn(
-						"[@grantcodes/astro] WARNING: Your astro.config.mjs has `resolve.noExternal` which duplicates `ssr.noExternal`. This is a known config bug. Remove `resolve.noExternal` to avoid unexpected behavior."
+						"[@grantcodes/astro] WARNING: Your astro.config.mjs has `resolve.noExternal` including `@grantcodes/ui`, which duplicates integration-managed `ssr.noExternal`. Remove `resolve.noExternal` to avoid unexpected behavior."
 					);
 				}
 			},

--- a/packages/astro/src/vite-config.ts
+++ b/packages/astro/src/vite-config.ts
@@ -6,7 +6,7 @@ export function getViteConfig() {
 			exclude: ["@grantcodes/ui"],
 		},
 		ssr: {
-			noExternal: ["@grantcodes/ui", "@grantcodes/astro-blocks"],
+			noExternal: ["@grantcodes/ui"],
 		},
 		plugins: [cssImportAttributes()],
 	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
   packages/astro:
     dependencies:
       '@grantcodes/style-dictionary':
-        specifier: workspace:^
+        specifier: ^1.5.1
         version: link:../style-dictionary
       '@grantcodes/ui':
-        specifier: workspace:^
+        specifier: ^2.12.0
         version: link:../ui
       '@lit-labs/ssr':
         specifier: ^3.3.1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,8 @@
 		"packages/style-dictionary": {
 			"package-name": "@grantcodes/style-dictionary"
 		},
-		"packages/astro-blocks": {
-			"package-name": "@grantcodes/astro-blocks"
+		"packages/astro": {
+			"package-name": "@grantcodes/astro"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- replace release automation references from `@grantcodes/astro-blocks` to `@grantcodes/astro` (release-please config, manifest, and publish workflow)
- make `@grantcodes/astro` publish-safe by switching workspace protocol deps to semver ranges
- remove stale `astro-blocks` script/docs references and align integration noExternal warning/config with current package topology

## Why
`@grantcodes/astro-blocks` is no longer a standalone package in this repo, and release automation should publish `@grantcodes/astro` instead.

## Validation
- `pnpm --filter @grantcodes/astro test`
- `pnpm build:astro`