### PR TITLE
Add Astro migration guardrails and SSR constructor diagnostics

### DIFF
--- a/packages/astro/MIGRATION.md
+++ b/packages/astro/MIGRATION.md
@@ -54,55 +54,201 @@ Remove the following packages from your project:
 
 ## Step 3: Update `astro.config.mjs`
 
+`@grantcodes/astro` should become the only place that owns Lit SSR wiring for this package set.
+Keep unrelated app config such as aliases, Starlight, sitemap, env schema, image settings, and other integrations.
+Remove the manual migration leftovers that the integration already handles for you.
+
 ### Before
 
 ```javascript
-import { defineConfig } from 'astro/config';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, envField } from 'astro/config';
 import lit from '@semantic-ui/astro-lit';
+import sitemap from '@astrojs/sitemap';
+import starlight from '@astrojs/starlight';
 import { cssImportAttributes } from '@grantcodes/ui/vite-plugin';
 
 export default defineConfig({
-  // ... other config
+  site: 'https://example.com',
   vite: {
-    optimizeDeps: {
-      exclude: ['@grantcodes/ui'],
+    resolve: {
+      alias: {
+        '@layouts': fileURLToPath(new URL('./src/layouts', import.meta.url)),
+        '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+      },
+      noExternal: ['@grantcodes/ui', '@grantcodes/astro-blocks'],
     },
     plugins: [cssImportAttributes()],
     ssr: {
       noExternal: ['@grantcodes/ui', '@grantcodes/astro-blocks'],
     },
-    resolve: {
-      noExternal: ['@grantcodes/ui', '@grantcodes/astro-blocks'],
-      // ... aliases
+  },
+  env: {
+    schema: {
+      TITLE: envField.string({ context: 'server', access: 'public' }),
     },
   },
   integrations: [
     lit(),
-    // ... other integrations
+    starlight({
+      title: 'Docs',
+    }),
+    sitemap(),
   ],
 });
 ```
 
 ### After
 
+Use a starter-like migrated config as the primary target shape:
+
+```javascript
+import { fileURLToPath } from 'node:url';
+import { defineConfig, envField } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+import starlight from '@astrojs/starlight';
+import ui from '@grantcodes/astro';
+import { envDefaults } from './integrations/env-defaults.ts';
+
+export default defineConfig({
+  site: 'https://example.com',
+  vite: {
+    resolve: {
+      alias: {
+        '@layouts': fileURLToPath(new URL('./src/layouts', import.meta.url)),
+        '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+      },
+    },
+  },
+  env: {
+    schema: {
+      TITLE: envField.string({
+        context: 'server',
+        access: 'public',
+        default: envDefaults.TITLE,
+      }),
+    },
+  },
+  integrations: [
+    ui({
+      theme: 'grantcodes',
+      ogImages: {
+        titleTemplate: envDefaults.META_TITLE_TEMPLATE,
+      },
+    }),
+    starlight({
+      title: 'Docs',
+    }),
+    sitemap(),
+  ],
+});
+```
+
+If you want the smallest safe config reference, this is the minimal fallback shape:
+
 ```javascript
 import { defineConfig } from 'astro/config';
 import ui from '@grantcodes/astro';
 
 export default defineConfig({
-  // ... other config (vite.resolve.alias can stay)
-  integrations: [
-    ui({ theme: 'grantcodes' }),
-    // ... other integrations
-  ],
+  integrations: [ui({ theme: 'grantcodes' })],
 });
 ```
 
-> You can safely remove `resolve.noExternal` — it was a known bug duplicating `ssr.noExternal`. The integration applies `ssr.noExternal` correctly for you.
->
-> If you pass `theme`, `@grantcodes/astro` will load the matching `@grantcodes/ui` theme stylesheet for you, so you no longer need a separate manual theme import just to activate a standard bundled theme.
+If your real app already has aliases, image settings, env schema, i18n, or other integrations, keep them. The migration is about removing obsolete Lit/Vite wiring, not flattening the rest of your app config.
 
-## Step 4: Update component imports
+### Remove the old integration-owned wiring
+
+```diff
+- import lit from '@semantic-ui/astro-lit';
+- import { cssImportAttributes } from '@grantcodes/ui/vite-plugin';
+  import ui from '@grantcodes/astro';
+
+  export default defineConfig({
+    vite: {
+-     plugins: [cssImportAttributes()],
+-     ssr: {
+-       noExternal: ['@grantcodes/ui', '@grantcodes/astro-blocks'],
+-     },
+      resolve: {
+-       noExternal: ['@grantcodes/ui', '@grantcodes/astro-blocks'],
+        alias: {
+          // keep app aliases
+        },
+      },
+    },
+    integrations: [
+-     lit(),
+-     manualLitRenderer(),
+-     manualLitHydration(),
++     ui({ theme: 'grantcodes' }),
+    ],
+  })
+```
+
+### Remove these manual wiring leftovers
+
+After migrating, delete these items from your old config if they were only there to support the previous Lit setup:
+
+- `import lit from '@semantic-ui/astro-lit'`
+- `import { cssImportAttributes } from '@grantcodes/ui/vite-plugin'`
+- manual `vite.plugins` entries for `cssImportAttributes()`
+- manual `vite.ssr.noExternal`
+- duplicated `vite.resolve.noExternal`
+- `vite.optimizeDeps.exclude` entries that only existed for `@grantcodes/ui`
+- any standalone manual Lit SSR renderer or hydration wiring tied to the old integration
+
+`vite.resolve.alias` and other app-specific config can stay.
+
+> `@grantcodes/astro` already applies the Lit SSR renderer, `cssImportAttributes()`, `vite.ssr.noExternal`, and `vite.optimizeDeps.exclude` for `@grantcodes/ui`.
+>
+> If you pass `theme`, `@grantcodes/astro` loads the matching bundled theme stylesheet for you. That replaces a separate manual theme import, but it does not inject `@grantcodes/ui/styles/base.css`.
+
+## What changed?
+
+The integration absorbs these manual configuration items:
+
+| Manual Config Item | What the integration does |
+|--------------------|---------------------------|
+| Lit SSR renderer (`@semantic-ui/astro-lit`) | Internal renderer via `addRenderer()` |
+| CSS import attributes Vite plugin (`cssImportAttributes()`) | Registered automatically via `updateConfig()` |
+| Vite `ssr.noExternal` | Applied for `@grantcodes/ui` and `@grantcodes/astro-blocks` |
+| Vite `optimizeDeps.exclude` | Applied for `@grantcodes/ui` |
+| Hydration support | Injected via `injectScript('before-hydration', ...)` |
+
+## Step 4: Keep the style contract intact
+
+Do **not** patch or strip `@grantcodes/ui` CSS imports to silence warnings or force a build through.
+That is unsupported, can break Lit shadow styles, and can surface `<style>undefined</style>` in rendered output.
+
+Use this decision tree after migrating:
+
+1. If you pass `theme` to `ui({ theme: 'grantcodes' })`, the integration loads the bundled theme stylesheet for you.
+2. If your app still relies on `@grantcodes/ui` global base styles, keep `@grantcodes/ui/styles/base.css` as a manual app import.
+3. Only remove the manual `base.css` import if your app already provides equivalent global UI base styles another way.
+4. If styles disappear after migration, restore the package CSS imports and remove bad manual Vite wiring instead of patching package source.
+
+Known-good split:
+
+```javascript
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import ui from '@grantcodes/astro';
+
+export default defineConfig({
+  integrations: [ui({ theme: 'grantcodes' })],
+});
+```
+
+```astro
+---
+import '@grantcodes/ui/styles/base.css';
+---
+```
+
+The integration-owned theme import and the app-owned `base.css` import solve different problems. Keep them separate in the docs and in migrated apps.
+
+## Step 5: Update component imports
 
 If you were using `@grantcodes/astro-blocks`, change your imports:
 
@@ -118,7 +264,7 @@ import { Hero, Cards } from '@grantcodes/astro/blocks';
 
 All other component imports from `@grantcodes/ui` remain unchanged.
 
-## Step 5: Verify the migration
+## Step 6: Verify the migration
 
 1. **Start the dev server:**
    ```bash
@@ -135,18 +281,6 @@ All other component imports from `@grantcodes/ui` remain unchanged.
 3. **Inspect the HTML output:**
    Look for `<template shadowrootmode="open">` inside your component tags in the rendered HTML. This confirms SSR is working.
 
-## What changed?
-
-The integration absorbs these manual configuration items:
-
-| Manual Config Item | What the integration does |
-|--------------------|---------------------------|
-| Lit SSR renderer (`@semantic-ui/astro-lit`) | Internal renderer via `addRenderer()` |
-| CSS import attributes Vite plugin (`cssImportAttributes()`) | Registered automatically via `updateConfig()` |
-| Vite `ssr.noExternal` | Applied for `@grantcodes/ui` and `@grantcodes/astro-blocks` |
-| Vite `optimizeDeps.exclude` | Applied for `@grantcodes/ui` |
-| Hydration support | Injected via `injectScript('before-hydration', ...)` |
-
 ## Troubleshooting
 
 ### "Warning about `resolve.noExternal`"
@@ -158,6 +292,21 @@ If you see this warning from `@grantcodes/astro`:
 ```
 
 **Fix:** Remove the `resolve.noExternal` array from your Vite config. It was incorrectly duplicating `ssr.noExternal` and is not needed.
+
+### `<style>undefined</style>` or missing component styles
+
+If a migrated app starts rendering `<style>undefined</style>` or web components lose their shadow styles, check for unsupported CSS import patching first.
+
+**Common cause:** stripping or rewriting `@grantcodes/ui` CSS imports in built package files to quiet warnings.
+
+**Fix path:**
+
+1. Restore the original `@grantcodes/ui` package CSS imports.
+2. Remove obsolete manual Vite wiring such as `cssImportAttributes()`, manual `vite.ssr.noExternal`, and duplicated `vite.resolve.noExternal`.
+3. Keep `ui({ theme })` for bundled theme loading.
+4. Keep `@grantcodes/ui/styles/base.css` as a manual app import unless equivalent global UI base styles already exist elsewhere in your app.
+
+Do not patch package source as the long-term fix.
 
 ### Build errors after migration
 

--- a/packages/astro/MIGRATION.md
+++ b/packages/astro/MIGRATION.md
@@ -219,7 +219,8 @@ The integration absorbs these manual configuration items:
 ## Step 4: Keep the style contract intact
 
 Do **not** patch or strip `@grantcodes/ui` CSS imports to silence warnings or force a build through.
-That is unsupported, can break Lit shadow styles, and can surface `<style>undefined</style>` in rendered output.
+That is unsupported, breaks Lit shadow styles, and can surface `<style>undefined</style>` in rendered output.
+The fix is to restore the original package CSS imports and trust the integration-owned Vite wiring instead of patching built package files.
 
 Use this decision tree after migrating:
 
@@ -228,7 +229,7 @@ Use this decision tree after migrating:
 3. Only remove the manual `base.css` import if your app already provides equivalent global UI base styles another way.
 4. If styles disappear after migration, restore the package CSS imports and remove bad manual Vite wiring instead of patching package source.
 
-Known-good split:
+Known-good split (this mirrors `apps/astro/src/layouts/Layout.astro`):
 
 ```javascript
 // astro.config.mjs
@@ -247,6 +248,13 @@ import '@grantcodes/ui/styles/base.css';
 ```
 
 The integration-owned theme import and the app-owned `base.css` import solve different problems. Keep them separate in the docs and in migrated apps.
+
+### Quick checklist
+
+- `ui({ theme: 'grantcodes' })` owns the bundled theme stylesheet
+- `@grantcodes/ui/styles/base.css` stays as a manual app import unless your app already replaces those base styles
+- `@grantcodes/astro` owns `cssImportAttributes()`, `vite.ssr.noExternal`, and related Lit SSR wiring
+- Restoring package CSS imports is the supported fix when you see `<style>undefined</style>`
 
 ## Step 5: Update component imports
 
@@ -305,6 +313,7 @@ If a migrated app starts rendering `<style>undefined</style>` or web components 
 2. Remove obsolete manual Vite wiring such as `cssImportAttributes()`, manual `vite.ssr.noExternal`, and duplicated `vite.resolve.noExternal`.
 3. Keep `ui({ theme })` for bundled theme loading.
 4. Keep `@grantcodes/ui/styles/base.css` as a manual app import unless equivalent global UI base styles already exist elsewhere in your app.
+5. Re-test after restoring the package imports instead of carrying a patch against compiled package source.
 
 Do not patch package source as the long-term fix.
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -69,7 +69,14 @@ Components render on the server and hydrate automatically in the browser. Use As
 
 ### Theme and Styles
 
-Set the UI theme in the integration when you want `@grantcodes/astro` to load it for you:
+Use this decision tree for styles after adopting `@grantcodes/astro`:
+
+1. If you pass `theme` to `ui({ theme: 'grantcodes' })`, the integration loads the bundled theme stylesheet for you.
+2. If your app still depends on the shared global UI base styles, keep `@grantcodes/ui/styles/base.css` as a manual app import.
+3. Only remove the manual `base.css` import if your app already provides equivalent global UI base styles another way.
+4. Do not document or expect automatic `base.css` injection from the integration. It does not happen.
+
+Known-good split (this mirrors `apps/astro/src/layouts/Layout.astro`):
 
 ```javascript
 // astro.config.mjs
@@ -90,12 +97,17 @@ export default defineConfig({
 
 Supported themes: `grantcodes`, `grantina`, `todomap`, `wireframe`.
 
-If you prefer to manage styles manually, you can still import CSS side effects yourself:
+```astro
+---
+import '@grantcodes/ui/styles/base.css';
+---
+```
+
+If you prefer to manage theme styles manually, import the theme stylesheet yourself. Keep theme CSS and `base.css` as separate decisions:
 
 ```astro
 ---
 import '@grantcodes/ui/styles/themes/grantcodes.css';
-import '@grantcodes/ui/styles/base.css';
 ---
 ```
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -52,7 +52,7 @@ import { GrantCodesButton } from '@grantcodes/ui/components/button/index.js';
 <grantcodes-button variant="primary">Click me</grantcodes-button>
 ```
 
-Components render on the server and hydrate automatically in the browser. Use Astro's `client:*` directives to control hydration timing when needed:
+Components render on the server by default. Choose a `client:*` directive only when you want a different rendering or hydration tradeoff:
 
 ```astro
 <!-- Hydrate as soon as the page loads -->
@@ -61,11 +61,22 @@ Components render on the server and hydrate automatically in the browser. Use As
 <!-- Hydrate when scrolled into view -->
 <grantcodes-button client:visible>Click me</grantcodes-button>
 
-<!-- Never hydrate — static server-rendered output only -->
+<!-- Skip SSR and render in the browser only -->
 <grantcodes-button client:only="lit">Click me</grantcodes-button>
 ```
 
-> Most components work fine without any directive. Add `client:load` or `client:visible` only when you need interactivity.
+> Most components work fine without any directive. `client:only="lit"` is a safe fallback when you want predictable browser-only rendering during or after migration.
+
+#### Directive decision matrix
+
+| Directive | Preserves SSR? | When to use it | Tradeoff |
+|-----------|----------------|----------------|----------|
+| No directive | Yes | Default choice for components that SSR cleanly and do not need immediate client interactivity | Best SSR output, but depends on SSR compatibility |
+| `client:load` | Yes | Use when the component should SSR first, then hydrate as soon as the page loads | More eager client work |
+| `client:visible` | Yes | Use when the component can wait to hydrate until it scrolls into view | Better client performance, delayed interactivity |
+| `client:only="lit"` | No | Use when you want browser-only rendering because of intermittent SSR constructor trouble, browser-only component behavior, or migration uncertainty around SSR | Gives up SSR benefits in exchange for predictable browser rendering |
+
+`client:only="lit"` is not just an emergency workaround. It is an acceptable long-term choice when your team prefers predictable browser rendering over SSR benefits for a specific component.
 
 ### Theme and Styles
 
@@ -150,6 +161,12 @@ Available blocks: `accordion`, `cards`, `countdown`, `cta`, `feature-list`, `gal
 ### Async Components Not SSRable
 
 Components that perform asynchronous operations during render (for example, fetching data inside `render()`) cannot be server-side rendered by `@lit-labs/ssr`. Use `client:only="lit"` for these components.
+
+Other migration signals that make `client:only="lit"` a good fit:
+
+- intermittent SSR constructor trouble during Astro rendering
+- components that rely on browser-only behavior
+- migrated apps where browser rendering is the safer long-term tradeoff than SSR for a specific component
 
 ### DOM Shim Interference
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "echo 'No build step required — source-based imports'",
     "fix": "echo 'No lint configured'",
-    "test": "node --test test/smoke.test.js"
+    "test": "tsx --test test/smoke.test.js test/ssr-constructor-diagnostics.test.js"
   },
   "keywords": [
     "astro",
@@ -46,6 +46,7 @@
     "lit": "^3.2.0"
   },
   "devDependencies": {
-    "astro": "^6.2.1"
+    "astro": "^6.2.1",
+    "tsx": "^4.0.0"
   }
 }

--- a/packages/astro/src/ssr/constructor-diagnostics.ts
+++ b/packages/astro/src/ssr/constructor-diagnostics.ts
@@ -1,0 +1,177 @@
+/**
+ * SSR CONSTRUCTOR DIAGNOSTICS
+ *
+ * Migration-focused SSR constructor guard and message builder for
+ * @grantcodes/astro.  Classifies custom element registration states
+ * that map to realistic migrated-app SSR failures and builds
+ * actionable, tag-aware error messages.
+ *
+ * Environment-split output:
+ *   - Development (isDev=true):  full remediation detail with likely
+ *     causes and next steps per D-01, D-02, D-03.
+ *   - Production  (isDev=false): shorter output that still names the
+ *     failing tag and likely-cause category per D-09, D-10.
+ *
+ * Design constraints (D-06, D-08):
+ *   - Infers only from the tag name, constructor lookup result, and
+ *     constructor shape.  Does NOT scan project config, docs, or
+ *     filesystem.
+ *   - Stays local to the SSR adapter.
+ */
+
+export type SsrDiagnosticCategory =
+  | 'missing-registration'
+  | 'invalid-constructor'
+  | 'non-lit-constructor';
+
+export interface SsrDiagnosticResult {
+  eligible: boolean;
+  category?: SsrDiagnosticCategory;
+  message: string;
+}
+
+// ── Helpers ──────────────────────────────────
+
+function lookupConstructor(tagName: string): typeof HTMLElement | null {
+  if (typeof customElements !== 'undefined') {
+    return customElements.get(tagName) || null;
+  }
+  return null;
+}
+
+// ── Message builders ─────────────────────────
+
+function buildDevMessage(tagName: string, category: SsrDiagnosticCategory): string {
+  switch (category) {
+    case 'missing-registration':
+      return (
+        `[SSR Error] <${tagName}> is not a registered custom element.\n` +
+        `\n` +
+        `Likely causes:\n` +
+        `  - The component import is missing or the element is not registered via customElements.define().\n` +
+        `  - If you migrated from manual Lit SSR wiring, check that the import path is correct.\n` +
+        `  - Leftover manual vite.ssr.noExternal or resolve.noExternal overrides may prevent registration.\n` +
+        `\n` +
+        `Next steps:\n` +
+        `  - Import the component in your Astro component frontmatter.\n` +
+        `  - Verify the element is registered after import.\n` +
+        `  - If SSR is not needed, use client:only="lit" to render this component in the browser only.\n` +
+        `\n` +
+        `See MIGRATION.md for the full migration guide.`
+      );
+
+    case 'invalid-constructor':
+      return (
+        `[SSR Error] <${tagName}> has an invalid constructor registration.\n` +
+        `\n` +
+        `customElements.get('${tagName}') returned a non-constructor value.\n` +
+        `\n` +
+        `Likely causes:\n` +
+        `  - A third-party script or leftover migration polyfill registered incorrectly.\n` +
+        `  - A leftover vite.resolve.noExternal override may interfere with the element registry.\n` +
+        `\n` +
+        `Next steps:\n` +
+        `  - Check what customElements.get('${tagName}') returns in your environment.\n` +
+        `  - Review astro.config.mjs for leftover Vite overrides.\n` +
+        `  - If SSR is not needed, use client:only="lit" to render this component in the browser only.\n` +
+        `\n` +
+        `See MIGRATION.md for the full migration guide.`
+      );
+
+    case 'non-lit-constructor':
+      return (
+        `[SSR Error] <${tagName}> is registered but not a Lit element.\n` +
+        `\n` +
+        `The constructor for <${tagName}> exists in the custom element registry ` +
+        `but is not Lit-based (missing _$litElement$).\n` +
+        `\n` +
+        `Likely causes:\n` +
+        `  - The component extends HTMLElement directly instead of LitElement.\n` +
+        `  - A different web component library registered under this tag name,\n` +
+        `    possibly from leftover migration dependencies.\n` +
+        `\n` +
+        `Next steps:\n` +
+        `  - Use only LitElement-based components for SSR compatibility.\n` +
+        `  - If SSR is not needed, use client:only="lit" to render this component in the browser only.\n` +
+        `  - For non-Lit elements, consider Astro's built-in HTML rendering.\n` +
+        `\n` +
+        `See MIGRATION.md for the full migration guide.`
+      );
+  }
+}
+
+function buildProdMessage(tagName: string, category: SsrDiagnosticCategory): string {
+  const causeHint: Record<SsrDiagnosticCategory, string> = {
+    'missing-registration':
+      'not imported or registered in the custom element registry',
+    'invalid-constructor':
+      'has an invalid or non-constructor registration',
+    'non-lit-constructor':
+      'registered element is not a LitElement component',
+  };
+
+  return (
+    `[SSR Error] <${tagName}> cannot be SSR-rendered: ${causeHint[category]}. ` +
+    `For detailed guidance, run in development mode or use client:only="lit".`
+  );
+}
+
+// ── Public API ───────────────────────────────
+
+/**
+ * Build a diagnostic message for a given tag and category,
+ * choosing the environment-appropriate level of detail.
+ *
+ * Exported separately so tests can verify the dev/prod split
+ * without needing a real element registration.
+ */
+export function buildSsrDiagnosticMessage(
+  tagName: string,
+  category: SsrDiagnosticCategory,
+  isDev: boolean,
+): string {
+  return isDev
+    ? buildDevMessage(tagName, category)
+    : buildProdMessage(tagName, category);
+}
+
+/**
+ * Classify a custom element tag for SSR eligibility.
+ *
+ * Returns:
+ *   - `eligible: true`  when the constructor exists and is Lit-based.
+ *   - `eligible: false` with a `category` and `message` explaining
+ *     the failure when registration is missing, invalid, or not Lit.
+ */
+export function getSsrConstructorDiagnostic(
+  tagName: string,
+  isDev: boolean = true,
+): SsrDiagnosticResult {
+  const Ctr = lookupConstructor(tagName);
+
+  if (!Ctr) {
+    return {
+      eligible: false,
+      category: 'missing-registration',
+      message: buildSsrDiagnosticMessage(tagName, 'missing-registration', isDev),
+    };
+  }
+
+  if (typeof Ctr !== 'function') {
+    return {
+      eligible: false,
+      category: 'invalid-constructor',
+      message: buildSsrDiagnosticMessage(tagName, 'invalid-constructor', isDev),
+    };
+  }
+
+  if (!(Ctr as unknown as Record<string, unknown>)._$litElement$) {
+    return {
+      eligible: false,
+      category: 'non-lit-constructor',
+      message: buildSsrDiagnosticMessage(tagName, 'non-lit-constructor', isDev),
+    };
+  }
+
+  return { eligible: true, message: '' };
+}

--- a/packages/astro/src/ssr/lit-renderer.ts
+++ b/packages/astro/src/ssr/lit-renderer.ts
@@ -12,6 +12,7 @@
 
 import { LitElementRenderer } from '@lit-labs/ssr/lib/lit-element-renderer.js';
 import * as parse5 from 'parse5';
+import { getSsrConstructorDiagnostic } from './constructor-diagnostics.js';
 
 function isCustomElementTag(name: unknown): boolean {
 	return typeof name === 'string' && /-/.test(name);
@@ -32,9 +33,14 @@ async function isLitElement(Component: unknown): Promise<boolean> {
 }
 
 export async function check(Component: unknown): Promise<boolean> {
-	// Lit doesn't support getting a tagName from a Constructor at this time.
-	// So this must be a string at the moment.
-	return !!(await isLitElement(Component));
+	// Use the same SSR eligibility rules as the render guard.
+	// For string tag names (the common SSR path), use the diagnostic check.
+	// For constructor-based components (legacy path), check _$litElement$ directly.
+	if (typeof Component === 'string') {
+		return getSsrConstructorDiagnostic(Component).eligible;
+	}
+	const Ctr = getCustomElementConstructor(Component as string | Function);
+	return !!Ctr?._$litElement$;
 }
 
 function* render(
@@ -45,6 +51,13 @@ function* render(
 	let tagName = Component;
 	if (typeof tagName !== 'string') {
 		tagName = (Component as Record<symbol, string>)[Symbol.for('tagName')];
+	}
+
+	// SSR constructor guard: fail early before opaque Lit crash path
+	const isDev = process.env.NODE_ENV !== 'production';
+	const { eligible, message } = getSsrConstructorDiagnostic(tagName, isDev);
+	if (!eligible) {
+		throw new Error(message);
 	}
 
 	const instance = new LitElementRenderer(tagName);

--- a/packages/astro/test/ssr-constructor-diagnostics.test.js
+++ b/packages/astro/test/ssr-constructor-diagnostics.test.js
@@ -1,0 +1,158 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+// ═══════════════════════════════════════════════════════════
+// Server-side DOM shim setup (mirrors shims/server-shim.ts
+// in plain JavaScript so Node 26's TS parser is not needed)
+// ═══════════════════════════════════════════════════════════
+import { customElements as litCE, HTMLElement as litShimHTMLElement } from '@lit-labs/ssr-dom-shim';
+
+if (typeof globalThis.document !== 'undefined' && globalThis.document) {
+  globalThis.document.currentScript = null;
+}
+
+globalThis.HTMLElement = litShimHTMLElement;
+
+globalThis.customElements = litCE;
+
+const litCeDefine = globalThis.customElements.define.bind(globalThis.customElements);
+globalThis.customElements.define = function shimDefine(tagName, Ctr) {
+  Ctr[Symbol.for('tagName')] = tagName;
+  return litCeDefine(tagName, Ctr);
+};
+// ═══════════════════════════════════════════════════════════
+
+// Modules under test
+import { getSsrConstructorDiagnostic, buildSsrDiagnosticMessage } from '../src/ssr/constructor-diagnostics.ts';
+import { renderToStaticMarkup, check } from '../src/ssr/lit-renderer.ts';
+
+// ──────────────────────────────────────────────
+// Task 1: Diagnostic contract
+// ──────────────────────────────────────────────
+describe('SSR constructor diagnostic contract', () => {
+  it('detects missing registration and names the tag with migration guidance', () => {
+    const result = getSsrConstructorDiagnostic('unknown-custom-element');
+
+    assert.strictEqual(result.eligible, false);
+    assert.strictEqual(result.category, 'missing-registration');
+    assert.ok(result.message.includes('unknown-custom-element'),
+      'dev message must name the failing tag');
+    assert.ok(result.message.includes('client:only'),
+      'dev message must mention client:only as intentional alternative');
+    assert.ok(result.message.includes('import') || result.message.includes('registration'),
+      'dev message must reference missing import or registration');
+  });
+
+  it('detects registered non-Lit constructors with tag-aware SSR ineligibility message', () => {
+    const tagName = 'non-lit-ssr-test';
+    class NonLit extends HTMLElement {}
+    customElements.define(tagName, NonLit);
+
+    const result = getSsrConstructorDiagnostic(tagName);
+
+    assert.strictEqual(result.eligible, false);
+    assert.strictEqual(result.category, 'non-lit-constructor');
+    assert.ok(result.message.includes(tagName),
+      'message must name the failing tag');
+  });
+
+  it('production diagnostic is shorter than dev but names tag and cause category', () => {
+    const tagNameForMsg = 'some-component';
+    const devMsg = buildSsrDiagnosticMessage(tagNameForMsg, 'missing-registration', true);
+    const prodMsg = buildSsrDiagnosticMessage(tagNameForMsg, 'missing-registration', false);
+
+    assert.ok(prodMsg.length < devMsg.length,
+      'production message must be shorter than development message');
+    assert.ok(prodMsg.includes(tagNameForMsg),
+      'production message must name the failing tag');
+    assert.ok(prodMsg.includes('register') || prodMsg.includes('import'),
+      'production message must reference the cause category');
+  });
+});
+
+// ──────────────────────────────────────────────
+// Task 2: Render path wiring
+// ──────────────────────────────────────────────
+describe('SSR render path pre-check', () => {
+  it('renderToStaticMarkup throws before LitElementRenderer for missing tag', async () => {
+    await assert.rejects(
+      () => renderToStaticMarkup('completely-unknown-tag-xyz'),
+      /completely-unknown-tag-xyz/,
+      'must throw a tag-aware error for missing registrations'
+    );
+  });
+
+  it('renders valid Lit element with Declarative Shadow DOM output', async () => {
+    const { LitElement, html } = await import('lit');
+    const tagName = 'test-ssr-valid-lit';
+
+    class TestValidLit extends LitElement {
+      render() {
+        return html`<p>SSR works</p>`;
+      }
+    }
+    customElements.define(tagName, TestValidLit);
+
+    const result = await renderToStaticMarkup(tagName, { class: 'test' });
+
+    assert.ok(result.html.includes(tagName),
+      'output must contain the component tag');
+    assert.ok(result.html.includes('<template shadowroot=') ||
+      result.html.includes('<template shadowrootmode=') ||
+      result.html.includes('shadowroot'),
+      'output must include Declarative Shadow DOM');
+  });
+
+  it('render path throws instead of auto-downgrading to placeholder markup', async () => {
+    await assert.rejects(
+      () => renderToStaticMarkup('does-not-exist-never-registered'),
+      (err) => {
+        assert.ok(err instanceof Error, 'must throw an Error instance');
+        assert.ok(
+          err.message.includes('does-not-exist-never-registered'),
+          'error must include the failing tag'
+        );
+        // The guard must not silently produce placeholder/downgrade rendering
+        assert.ok(
+          !err.message.toLowerCase().includes('placeholder'),
+          'must not mention placeholder as a fallback option in the error'
+        );
+        return true;
+      }
+    );
+  });
+});
+
+// ──────────────────────────────────────────────
+// check() consistency
+// ──────────────────────────────────────────────
+describe('check() consistency', () => {
+  it('returns false for unregistered tag', async () => {
+    const result = await check('never-registered-check');
+    assert.strictEqual(result, false);
+  });
+
+  it('returns false for registered non-Lit element', async () => {
+    const tagName = 'non-lit-check-test';
+    class NonLitCheck extends HTMLElement {}
+    customElements.define(tagName, NonLitCheck);
+
+    const result = await check(tagName);
+    assert.strictEqual(result, false);
+  });
+
+  it('returns true for valid Lit element', async () => {
+    const { LitElement, html } = await import('lit');
+    const tagName = 'valid-lit-check-test';
+
+    class ValidLitCheck extends LitElement {
+      render() {
+        return html`<p>ok</p>`;
+      }
+    }
+    customElements.define(tagName, ValidLitCheck);
+
+    const result = await check(tagName);
+    assert.strictEqual(result, true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.0.0(@types/node@25.5.0)(typescript@5.4.5)
       '@storybook/html-vite':
         specifier: ^10.2.19
-        version: 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+        version: 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       turbo:
         specifier: ^2.8.17
         version: 2.8.17
@@ -31,7 +31,7 @@ importers:
         version: 3.7.2
       '@astrojs/starlight':
         specifier: ^0.38.4
-        version: 0.38.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2))
+        version: 0.38.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2))
       '@grantcodes/astro':
         specifier: workspace:*
         version: link:../../packages/astro
@@ -43,7 +43,7 @@ importers:
         version: link:../../packages/ui
       astro:
         specifier: ^6.2.1
-        version: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
+        version: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
       astro-seo:
         specifier: ^1.1.0
         version: 1.1.0(prettier@3.8.1)(typescript@5.4.5)
@@ -96,7 +96,10 @@ importers:
     devDependencies:
       astro:
         specifier: ^6.2.1
-        version: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
+        version: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
 
   packages/astro-og-images:
     dependencies:
@@ -109,7 +112,7 @@ importers:
         version: 2.6.2
       astro:
         specifier: ^5.5.2
-        version: 5.18.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
+        version: 5.18.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
       satori:
         specifier: ^0.12.1
         version: 0.12.2
@@ -171,13 +174,13 @@ importers:
         version: 1.58.2
       '@storybook/addon-docs':
         specifier: ^10.1.4
-        version: 10.2.19(@types/react@19.2.14)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+        version: 10.2.19(@types/react@19.2.14)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-themes':
         specifier: ^10.1.4
         version: 10.2.19(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/web-components-vite':
         specifier: ^10.1.4
-        version: 10.2.19(esbuild@0.27.4)(lit@3.3.2)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+        version: 10.2.19(esbuild@0.27.4)(lit@3.3.2)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@wc-toolkit/cem-inheritance':
         specifier: ^1.2.2
         version: 1.2.2
@@ -213,7 +216,7 @@ importers:
         version: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vite:
         specifier: ^7.2.6
-        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -2960,6 +2963,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
@@ -4385,6 +4391,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -4776,6 +4785,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo-darwin-64@2.8.17:
     resolution: {integrity: sha512-ZFkv2hv7zHpAPEXBF6ouRRXshllOavYc+jjcrYyVHvxVTTwJWsBZwJ/gpPzmOKGvkSjsEyDO5V6aqqtZzwVF+Q==}
@@ -5568,12 +5582,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2))':
+  '@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
+      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5607,17 +5621,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2))':
+  '@astrojs/starlight@0.38.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/mdx': 5.0.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2))
+      '@astrojs/mdx': 5.0.4(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
-      astro-expressive-code: 0.41.7(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2))
+      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
+      astro-expressive-code: 0.41.7(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6847,10 +6861,10 @@ snapshots:
   '@simple-libs/stream-utils@1.2.0':
     optional: true
 
-  '@storybook/addon-docs@10.2.19(@types/react@19.2.14)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/addon-docs@10.2.19(@types/react@19.2.14)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -6869,51 +6883,51 @@ snapshots:
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.4
       rollup: 4.59.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.4
       rollup: 4.59.0
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/html-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/html-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/html': 10.2.19(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -6939,9 +6953,9 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/web-components-vite@10.2.19(esbuild@0.27.4)(lit@3.3.2)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@storybook/web-components-vite@10.2.19(esbuild@0.27.4)(lit@3.3.2)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/web-components': 10.2.19(lit@3.3.2)(storybook@10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook: 10.2.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -7307,9 +7321,9 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)):
+  astro-expressive-code@0.41.7(astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)):
     dependencies:
-      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2)
+      astro: 6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2)
       rehype-expressive-code: 0.41.7
 
   astro-seo@1.1.0(prettier@3.8.1)(typescript@5.4.5):
@@ -7320,7 +7334,7 @@ snapshots:
       - prettier-plugin-astro
       - typescript
 
-  astro@5.18.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2):
+  astro@5.18.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -7377,8 +7391,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -7422,7 +7436,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.4.5)(yaml@2.8.2):
+  astro@6.2.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
@@ -7473,8 +7487,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -8445,6 +8459,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   git-raw-commits@4.0.0:
     dependencies:
@@ -10380,6 +10398,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -10886,6 +10906,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.17:
     optional: true
 
@@ -11127,7 +11154,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11140,9 +11167,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11155,9 +11183,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11170,15 +11199,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitefu@1.1.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:


### PR DESCRIPTION
## Summary
- harden `@grantcodes/astro` migration docs with explicit config-removal guidance, style-contract troubleshooting, and `base.css`/`client:*` decision support
- add tag-aware SSR constructor diagnostics that fail before opaque Lit renderer crashes and point to likely migration causes plus next steps
- cover the new SSR guard with focused tests while preserving the existing Astro smoke-test path