### PR TITLE
fix OG image font handling and align Grantina assets

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -36,7 +36,7 @@ export default defineConfig({
 });
 ```
 
-Passing `theme` auto-loads the matching `@grantcodes/ui` theme stylesheet for the site and gives bundled OG image generation a matching set of default colors and fonts.
+Passing `theme` auto-loads the matching `@grantcodes/ui` theme stylesheet for the site and gives bundled OG image generation matching default colors plus bundled local font defaults or fallbacks, depending on the theme.
 
 ## Usage
 
@@ -140,6 +140,10 @@ export default defineConfig({
   ],
 });
 ```
+
+- Set `ogImages: false` to disable bundled OG generation entirely.
+- OG images use the resolved site favicon as their default mark.
+- Theme OG defaults always match the selected theme colors. Grantina now uses package-managed local Albert Sans + Vidaloka assets for OG generation, while other themes keep their existing local font defaults.
 
 ## Blocks
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "echo 'No build step required — source-based imports'",
     "fix": "echo 'No lint configured'",
-    "test": "tsx --test test/smoke.test.js test/ssr-constructor-diagnostics.test.js"
+    "test": "tsx --test test/smoke.test.js test/ssr-constructor-diagnostics.test.js test/og-images.test.js"
   },
   "keywords": [
     "astro",
@@ -32,10 +32,10 @@
   "dependencies": {
     "@grantcodes/style-dictionary": "^1.5.1",
     "@grantcodes/ui": "^2.12.0",
-    "@resvg/resvg-js": "^2.6.2",
     "@lit-labs/ssr": "^3.3.1",
     "@lit-labs/ssr-client": "^1.1.7",
     "@lit-labs/ssr-dom-shim": "^1.3.0",
+    "@resvg/resvg-js": "^2.6.2",
     "colorjs.io": "^0.5.2",
     "marked": "^17.0.4",
     "parse5": "^7.2.1",

--- a/packages/astro/src/og-images.ts
+++ b/packages/astro/src/og-images.ts
@@ -11,6 +11,8 @@ export interface AstroOgImagesOptions {
   titleFontFile?: string
   bodyFontFile?: string
   fontName?: string
+  titleFontName?: string
+  bodyFontName?: string
   titleFontWeight?: number
   bodyFontWeight?: number
   foregroundColor?: string
@@ -38,6 +40,8 @@ const defaultOptions: Required<AstroOgImagesOptions> = {
   titleFontFile: './node_modules/@grantcodes/style-dictionary/assets/fonts/greycliff-heavy.woff',
   bodyFontFile: './node_modules/@grantcodes/style-dictionary/assets/fonts/greycliff-regular.woff',
   fontName: 'Greycliff',
+  titleFontName: 'Greycliff',
+  bodyFontName: 'Greycliff',
   titleFontWeight: 900,
   bodyFontWeight: 500,
   foregroundColor: '#f0f1f3',
@@ -63,12 +67,12 @@ function detectFaviconPath(): string {
 
 export function resolveOgOptions(input: ResolveOgOptionsInput = {}): ResolvedOgOptions {
   const ogImages = input.ogImages
-  if (typeof ogImages === 'undefined') {
+
+  // Explicit false or undefined → disabled
+  if (ogImages === false || typeof ogImages === 'undefined') {
     return {
       enabled: false,
-      options: {
-        ...defaultOptions,
-      },
+      options: { ...defaultOptions },
     }
   }
 
@@ -85,14 +89,37 @@ export function resolveOgOptions(input: ResolveOgOptionsInput = {}): ResolvedOgO
     ...explicitOptions,
   }
 
+  const titleFontName = explicitOptions.titleFontName
+    || input.themeDefaults?.titleFontName
+    || explicitOptions.fontName
+    || input.themeDefaults?.fontName
+    || defaultOptions.titleFontName
+
+  const bodyFontName = explicitOptions.bodyFontName
+    || input.themeDefaults?.bodyFontName
+    || explicitOptions.fontName
+    || input.themeDefaults?.fontName
+    || defaultOptions.bodyFontName
+
   return {
     enabled: true,
     options: {
       ...rawOptions,
+      titleFontName,
+      bodyFontName,
       foregroundColor: normalizeColor(rawOptions.foregroundColor, input.colorScheme),
       backgroundColor: normalizeColor(rawOptions.backgroundColor, input.colorScheme),
     },
   }
+}
+
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
 }
 
 export function getOgHooks(options: Required<AstroOgImagesOptions>) {
@@ -135,8 +162,8 @@ export function getOgHooks(options: Required<AstroOgImagesOptions>) {
             const descriptionQuery = html.match(/<meta name="description" content="(.*?)"/)
 
             const titleWithTemplate = titleQuery ? titleQuery[1] : ''
-            const title = titleWithTemplate.replace(options.titleTemplate.replace('%s', ''), '')
-            const description = descriptionQuery ? descriptionQuery[1] : ''
+            const title = decodeHtmlEntities(titleWithTemplate.replace(options.titleTemplate.replace('%s', ''), ''))
+            const description = decodeHtmlEntities(descriptionQuery ? descriptionQuery[1] : '')
 
             const svg = await satori(
               {
@@ -150,7 +177,7 @@ export function getOgHooks(options: Required<AstroOgImagesOptions>) {
                     color: options.foregroundColor,
                     backgroundColor: options.backgroundColor,
                     padding: '55px 70px',
-                    fontFamily: options.fontName,
+                    fontFamily: options.bodyFontName || options.fontName,
                     fontSize: 72,
                   },
                   children: [
@@ -167,6 +194,7 @@ export function getOgHooks(options: Required<AstroOgImagesOptions>) {
                         style: {
                           marginTop: 96,
                           fontWeight: options.titleFontWeight,
+                          fontFamily: options.titleFontName || options.fontName,
                         },
                         children: title,
                       },
@@ -190,13 +218,13 @@ export function getOgHooks(options: Required<AstroOgImagesOptions>) {
                 height: options.height,
                 fonts: [
                   {
-                    name: options.fontName,
+                    name: options.titleFontName || options.fontName,
                     data: titleFont,
                     weight: options.titleFontWeight,
                     style: 'normal',
                   },
                   {
-                    name: options.fontName,
+                    name: options.bodyFontName || options.fontName,
                     data: bodyFont,
                     weight: options.bodyFontWeight,
                     style: 'normal',

--- a/packages/astro/src/themes.ts
+++ b/packages/astro/src/themes.ts
@@ -12,7 +12,12 @@ import {
   GThemeTypographyBodyFontWeight as GThemeTypographyBodyFontWeightGrantina,
   GThemeTypographyH1FontWeight as GThemeTypographyH1FontWeightGrantina,
   GTypographyFontFamilyAlbert,
+  GTypographyFontFamilyVidaloka,
 } from '@grantcodes/style-dictionary/grantina/js'
+import {
+  grantinaBodyFontPath,
+  grantinaTitleFontPath,
+} from '@grantcodes/style-dictionary/grantina/fonts'
 import {
   GThemeColorBackgroundDefault as GThemeColorBackgroundDefaultTodomap,
   GThemeColorContentDefault as GThemeColorContentDefaultTodomap,
@@ -25,7 +30,6 @@ import {
   GThemeColorContentDefault as GThemeColorContentDefaultWireframe,
   GThemeTypographyBodyFontWeight as GThemeTypographyBodyFontWeightWireframe,
   GThemeTypographyH1FontWeight as GThemeTypographyH1FontWeightWireframe,
-  GTypographyFontFamilyHelvetica,
 } from '@grantcodes/style-dictionary/wireframe/js'
 
 export const UI_THEMES = ['grantcodes', 'grantina', 'todomap', 'wireframe'] as const
@@ -36,6 +40,8 @@ export type UiColorScheme = 'light' | 'dark'
 interface ThemeDefinition {
   stylesheetImport: string
   fontName: string
+  titleFontName: string
+  bodyFontName: string
   titleFontFile: string
   bodyFontFile: string
   titleFontWeight: string
@@ -48,6 +54,8 @@ export interface ResolvedTheme {
   name: UiThemeName
   stylesheetImport: string
   fontName: string
+  titleFontName: string
+  bodyFontName: string
   titleFontFile: string
   bodyFontFile: string
   titleFontWeight: number
@@ -59,7 +67,9 @@ export interface ResolvedTheme {
 const THEME_DEFINITIONS: Record<UiThemeName, ThemeDefinition> = {
   grantcodes: {
     stylesheetImport: '@grantcodes/ui/styles/themes/grantcodes.css',
-    fontName: GTypographyFontFamilyGreycliff.split(',')[0].trim(),
+    fontName: firstFontFamily(GTypographyFontFamilyGreycliff),
+    titleFontName: firstFontFamily(GTypographyFontFamilyGreycliff),
+    bodyFontName: firstFontFamily(GTypographyFontFamilyGreycliff),
     titleFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-heavy.woff'),
     bodyFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-regular.woff'),
     titleFontWeight: GThemeTypographyH1FontWeightGrantcodes,
@@ -69,9 +79,11 @@ const THEME_DEFINITIONS: Record<UiThemeName, ThemeDefinition> = {
   },
   grantina: {
     stylesheetImport: '@grantcodes/ui/styles/themes/grantina.css',
-    fontName: GTypographyFontFamilyAlbert.split(',')[0].trim(),
-    titleFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-heavy.woff'),
-    bodyFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-regular.woff'),
+    fontName: firstFontFamily(GTypographyFontFamilyAlbert),
+    titleFontName: firstFontFamily(GTypographyFontFamilyVidaloka),
+    bodyFontName: firstFontFamily(GTypographyFontFamilyAlbert),
+    titleFontFile: grantinaTitleFontPath,
+    bodyFontFile: grantinaBodyFontPath,
     titleFontWeight: GThemeTypographyH1FontWeightGrantina,
     bodyFontWeight: GThemeTypographyBodyFontWeightGrantina,
     foregroundColor: GThemeColorContentDefaultGrantina,
@@ -79,7 +91,9 @@ const THEME_DEFINITIONS: Record<UiThemeName, ThemeDefinition> = {
   },
   todomap: {
     stylesheetImport: '@grantcodes/ui/styles/themes/todomap.css',
-    fontName: GTypographyFontFamilyQuicksand.split(',')[0].trim(),
+    fontName: firstFontFamily(GTypographyFontFamilyQuicksand),
+    titleFontName: firstFontFamily(GTypographyFontFamilyQuicksand),
+    bodyFontName: firstFontFamily(GTypographyFontFamilyQuicksand),
     titleFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/quicksand-bold.woff'),
     bodyFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/quicksand-regular.woff'),
     titleFontWeight: GThemeTypographyH1FontWeightTodomap,
@@ -89,7 +103,11 @@ const THEME_DEFINITIONS: Record<UiThemeName, ThemeDefinition> = {
   },
   wireframe: {
     stylesheetImport: '@grantcodes/ui/styles/themes/wireframe.css',
-    fontName: GTypographyFontFamilyHelvetica.split(',')[0].trim(),
+    // OG generation uses bundled local fallbacks until a local Helvetica-compatible
+    // asset is shipped for the wireframe theme.
+    fontName: firstFontFamily(GTypographyFontFamilyGreycliff),
+    titleFontName: firstFontFamily(GTypographyFontFamilyGreycliff),
+    bodyFontName: firstFontFamily(GTypographyFontFamilyGreycliff),
     titleFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-bold.woff'),
     bodyFontFile: resolveFontPath('@grantcodes/style-dictionary/assets/fonts/greycliff-regular.woff'),
     titleFontWeight: GThemeTypographyH1FontWeightWireframe,
@@ -130,6 +148,10 @@ function splitLightDarkArgs(input: string): [string, string] | null {
   return null
 }
 
+function firstFontFamily(value: string): string {
+  return value.split(',')[0].trim().replace(/^['"]|['"]$/g, '')
+}
+
 export function resolveColorSchemeToken(value: string, colorScheme: UiColorScheme = 'dark'): string {
   const pair = splitLightDarkArgs(value.trim())
   if (!pair) {
@@ -154,6 +176,8 @@ export function resolveTheme(
     name: theme,
     stylesheetImport: definition.stylesheetImport,
     fontName: definition.fontName,
+    titleFontName: definition.titleFontName,
+    bodyFontName: definition.bodyFontName,
     titleFontFile: definition.titleFontFile,
     bodyFontFile: definition.bodyFontFile,
     titleFontWeight: toFontWeight(definition.titleFontWeight, 700),

--- a/packages/astro/test/og-images.test.js
+++ b/packages/astro/test/og-images.test.js
@@ -128,8 +128,8 @@ describe('resolveTheme OG fonts', () => {
     assert.strictEqual(result.fontName, 'Albert Sans');
     assert.strictEqual(result.titleFontName, 'Vidaloka');
     assert.strictEqual(result.bodyFontName, 'Albert Sans');
-    assert.match(result.titleFontFile, /vidaloka-latin-400-normal\.woff2$/);
-    assert.match(result.bodyFontFile, /albert-sans-latin-wght-normal\.woff2$/);
+    assert.match(result.titleFontFile, /vidaloka-latin-400-normal\.woff$/);
+    assert.match(result.bodyFontFile, /albert-sans-latin-500-normal\.woff$/);
   });
 
   it('uses a bundled local fallback font for wireframe OG output', () => {

--- a/packages/astro/test/og-images.test.js
+++ b/packages/astro/test/og-images.test.js
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  resolveOgOptions,
+  decodeHtmlEntities,
+} from '../src/og-images.ts';
+import { resolveTheme } from '../src/themes.ts';
+
+// ──────────────────────────────────────────────
+// resolveOgOptions: ogImages false handling
+// ──────────────────────────────────────────────
+describe('resolveOgOptions', () => {
+  it('disables OG when ogImages is false', () => {
+    const result = resolveOgOptions({ ogImages: false });
+    assert.strictEqual(result.enabled, false);
+    assert.ok(result.options);
+  });
+
+  it('disables OG when ogImages is undefined (no options)', () => {
+    const result = resolveOgOptions();
+    assert.strictEqual(result.enabled, false);
+    assert.ok(result.options);
+  });
+
+  it('disables OG when ogImages is undefined (explicit undefined)', () => {
+    const result = resolveOgOptions({ ogImages: undefined });
+    assert.strictEqual(result.enabled, false);
+    assert.ok(result.options);
+  });
+
+  it('enables OG when ogImages is true', () => {
+    const result = resolveOgOptions({ ogImages: true });
+    assert.strictEqual(result.enabled, true);
+    assert.ok(result.options);
+  });
+
+  it('enables OG when ogImages is an object', () => {
+    const result = resolveOgOptions({
+      ogImages: { fontName: 'CustomFont' },
+    });
+    assert.strictEqual(result.enabled, true);
+    assert.strictEqual(result.options.fontName, 'CustomFont');
+  });
+
+  it('merges custom options with defaults', () => {
+    const result = resolveOgOptions({
+      ogImages: { fontName: 'CustomFont' },
+    });
+    assert.strictEqual(result.options.width, 1200);
+    assert.strictEqual(result.options.height, 630);
+    assert.strictEqual(result.options.fontName, 'CustomFont');
+  });
+
+  it('uses themeDefaults when provided', () => {
+    const result = resolveOgOptions({
+      ogImages: true,
+      themeDefaults: { fontName: 'ThemeFont' },
+    });
+    assert.strictEqual(result.enabled, true);
+    assert.strictEqual(result.options.fontName, 'ThemeFont');
+    assert.strictEqual(result.options.titleFontName, 'ThemeFont');
+    assert.strictEqual(result.options.bodyFontName, 'ThemeFont');
+  });
+
+  it('explicit ogImages object overrides themeDefaults', () => {
+    const result = resolveOgOptions({
+      ogImages: { fontName: 'ExplicitFont' },
+      themeDefaults: { fontName: 'ThemeFont' },
+    });
+    assert.strictEqual(result.options.fontName, 'ExplicitFont');
+    assert.strictEqual(result.options.titleFontName, 'ExplicitFont');
+    assert.strictEqual(result.options.bodyFontName, 'ExplicitFont');
+  });
+
+  it('supports separate title and body font names', () => {
+    const result = resolveOgOptions({
+      ogImages: true,
+      themeDefaults: { titleFontName: 'TitleFont', bodyFontName: 'BodyFont' },
+    });
+    assert.strictEqual(result.options.titleFontName, 'TitleFont');
+    assert.strictEqual(result.options.bodyFontName, 'BodyFont');
+  });
+});
+
+// ──────────────────────────────────────────────
+// decodeHtmlEntities: HTML entity decoding
+// ──────────────────────────────────────────────
+describe('decodeHtmlEntities', () => {
+  it('decodes &amp; to &', () => {
+    assert.strictEqual(decodeHtmlEntities('Foo &amp; Bar'), 'Foo & Bar');
+  });
+
+  it('decodes &lt; and &gt;', () => {
+    assert.strictEqual(decodeHtmlEntities('&lt;div&gt;'), '<div>');
+  });
+
+  it('decodes &quot;', () => {
+    assert.strictEqual(
+      decodeHtmlEntities('He said &quot;hello&quot;'),
+      'He said "hello"',
+    );
+  });
+
+  it('decodes &#39; (single quote)', () => {
+    assert.strictEqual(decodeHtmlEntities("It&#39;s nice"), "It's nice");
+  });
+
+  it('handles strings with no entities', () => {
+    assert.strictEqual(decodeHtmlEntities('Plain text'), 'Plain text');
+  });
+
+  it('decodes multiple entity types in one string', () => {
+    assert.strictEqual(
+      decodeHtmlEntities('&lt;title&gt;Foo &amp; Bar &quot;Baz&quot;&lt;/title&gt;'),
+      '<title>Foo & Bar "Baz"</title>',
+    );
+  });
+
+  it('decodes empty string', () => {
+    assert.strictEqual(decodeHtmlEntities(''), '');
+  });
+});
+
+describe('resolveTheme OG fonts', () => {
+  it('uses package-managed local Grantina fonts for OG output', () => {
+    const result = resolveTheme('grantina');
+    assert.strictEqual(result.fontName, 'Albert Sans');
+    assert.strictEqual(result.titleFontName, 'Vidaloka');
+    assert.strictEqual(result.bodyFontName, 'Albert Sans');
+    assert.match(result.titleFontFile, /vidaloka-latin-400-normal\.woff2$/);
+    assert.match(result.bodyFontFile, /albert-sans-latin-wght-normal\.woff2$/);
+  });
+
+  it('uses a bundled local fallback font for wireframe OG output', () => {
+    const result = resolveTheme('wireframe');
+    assert.strictEqual(result.fontName, 'Greycliff');
+    assert.match(result.titleFontFile, /greycliff-bold\.woff$/);
+    assert.match(result.bodyFontFile, /greycliff-regular\.woff$/);
+  });
+});

--- a/packages/astro/test/smoke.test.js
+++ b/packages/astro/test/smoke.test.js
@@ -119,14 +119,14 @@ describe("@grantcodes/astro smoke test", () => {
         cwd: tempDir,
         stdio: "pipe",
         encoding: "utf8",
-        timeout: 120000,
+        timeout: 300000,
       });
 
       execSync("npx astro build", {
         cwd: tempDir,
         stdio: "pipe",
         encoding: "utf8",
-        timeout: 120000,
+        timeout: 300000,
       });
 
       html = fs.readFileSync(path.join(tempDir, "dist", "index.html"), "utf8");

--- a/packages/style-dictionary/assets/fonts/grantina.css
+++ b/packages/style-dictionary/assets/fonts/grantina.css
@@ -1,1 +1,47 @@
-@import url(https://fonts.bunny.net/css?family=albert-sans:400,600|pinyon-script:400|vidaloka:400);
+@font-face {
+	font-family: 'Vidaloka';
+	font-style: normal;
+	font-weight: 400;
+	font-display: swap;
+	src: url('@fontsource/vidaloka/files/vidaloka-latin-400-normal.woff2') format('woff2'),
+		url('@fontsource/vidaloka/files/vidaloka-latin-400-normal.woff') format('woff');
+	unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+	font-family: 'Albert Sans';
+	font-style: normal;
+	font-weight: 100 900;
+	font-display: swap;
+	src: url('@fontsource-variable/albert-sans/files/albert-sans-latin-ext-wght-normal.woff2') format('woff2-variations');
+	unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+@font-face {
+	font-family: 'Albert Sans';
+	font-style: normal;
+	font-weight: 100 900;
+	font-display: swap;
+	src: url('@fontsource-variable/albert-sans/files/albert-sans-latin-wght-normal.woff2') format('woff2-variations');
+	unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+	font-family: 'Pinyon Script';
+	font-style: normal;
+	font-weight: 400;
+	font-display: swap;
+	src: url('@fontsource/pinyon-script/files/pinyon-script-latin-ext-400-normal.woff2') format('woff2'),
+		url('@fontsource/pinyon-script/files/pinyon-script-latin-ext-400-normal.woff') format('woff');
+	unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+@font-face {
+	font-family: 'Pinyon Script';
+	font-style: normal;
+	font-weight: 400;
+	font-display: swap;
+	src: url('@fontsource/pinyon-script/files/pinyon-script-latin-400-normal.woff2') format('woff2'),
+		url('@fontsource/pinyon-script/files/pinyon-script-latin-400-normal.woff') format('woff');
+	unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}

--- a/packages/style-dictionary/lib/grantina-fonts.js
+++ b/packages/style-dictionary/lib/grantina-fonts.js
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url'
+
+function resolveFontPath(importPath) {
+	try {
+		const resolved = import.meta.resolve(importPath)
+		return resolved.startsWith('file:') ? fileURLToPath(resolved) : resolved
+	} catch {
+		return fileURLToPath(new URL(`../node_modules/${importPath}`, import.meta.url))
+	}
+}
+
+export const grantinaTitleFontPath = resolveFontPath(
+	'@fontsource/vidaloka/files/vidaloka-latin-400-normal.woff',
+)
+
+export const grantinaBodyFontPath = resolveFontPath(
+	'@fontsource/albert-sans/files/albert-sans-latin-500-normal.woff',
+)

--- a/packages/style-dictionary/package.json
+++ b/packages/style-dictionary/package.json
@@ -19,6 +19,7 @@
 		"./todomap/json": "./dist/json/todomap/tokens.json",
 		"./grantina/css": "./dist/css/grantina/tokens.css",
 		"./grantina/css/theme": "./dist/css/grantina/grantina.css",
+		"./grantina/fonts": "./lib/grantina-fonts.js",
 		"./grantina/js": "./dist/js/grantina/style-dictionary.js",
 		"./grantina/json": "./dist/json/grantina/tokens.json",
 		"./assets/fonts/greycliff": "./assets/fonts/greycliff.css",
@@ -63,10 +64,15 @@
 		"style-dictionary": "^5.0.1"
 	},
 	"dependencies": {
+		"@fontsource-variable/albert-sans": "^5.2.8",
+		"@fontsource/albert-sans": "^5.2.8",
+		"@fontsource/pinyon-script": "^5.2.8",
+		"@fontsource/vidaloka": "^5.2.7",
 		"colorjs.io": "^0.5.2"
 	},
 	"files": [
 		"dist/**/*",
+		"lib/**/*",
 		"assets/**/*",
 		"README.md",
 		"CHANGELOG.md"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,18 @@ importers:
 
   packages/style-dictionary:
     dependencies:
+      '@fontsource-variable/albert-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/albert-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/pinyon-script':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/vidaloka':
+        specifier: ^5.2.7
+        version: 5.2.7
       colorjs.io:
         specifier: ^0.5.2
         version: 0.5.2
@@ -912,6 +924,18 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.7':
     resolution: {integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==}
+
+  '@fontsource-variable/albert-sans@5.2.8':
+    resolution: {integrity: sha512-hDtxW/K8gj8y+42BvH50UUIgpY7oriWXi+79Aam0MN+BIwk2CyN3kI/NP37e39PvC1625UFHEyBi48IcMy3DiA==}
+
+  '@fontsource/albert-sans@5.2.8':
+    resolution: {integrity: sha512-DCBojiRL/lxTC+fQPwg2eoszTo4dX3uH6iWmpsZ0ytn8rGfhUNl5QJjZNEVQmbZgeRRDZqc5iaPTl1+9AxU2Lg==}
+
+  '@fontsource/pinyon-script@5.2.8':
+    resolution: {integrity: sha512-X2besX/JgOOPGwPy3CX6InZwmMQ7wmLGNGTWDHHhUfpfSj94TbfTieFpDW2/PoFLjWswiTdWwlOM8rQY0QGEVg==}
+
+  '@fontsource/vidaloka@5.2.7':
+    resolution: {integrity: sha512-LPbfgNfnRuH8WkAaA8149DLTfKOwT+ap+23d2JagHkqwYpmaIHOz79MV1RR7rW64VHtURwpVHrNEl/RvLgdFhA==}
 
   '@github/catalyst@1.8.0':
     resolution: {integrity: sha512-uLpi/D/mKfylYaFLfzNuloXNENi0AlcM0Z7hwYLH8Z030jBCr+ueMdX2xLxCzpMH/keYXKh0uPrHSMfcbxU6KA==}
@@ -6203,6 +6227,14 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.7':
     dependencies:
       '@expressive-code/core': 0.41.7
+
+  '@fontsource-variable/albert-sans@5.2.8': {}
+
+  '@fontsource/albert-sans@5.2.8': {}
+
+  '@fontsource/pinyon-script@5.2.8': {}
+
+  '@fontsource/vidaloka@5.2.7': {}
 
   '@github/catalyst@1.8.0': {}
 


### PR DESCRIPTION
## Summary
- remove the redundant OG logo override, add OG-specific coverage, and keep the README aligned with the actual favicon-based behavior
- move Grantina font ownership into `@grantcodes/style-dictionary`, switch its web font CSS to local package-managed assets, and expose style-dictionary font paths for Astro OG generation
- update Astro OG theme/font resolution to support separate title/body font files and names, then verify the end-to-end path with tests and a successful Astro starter build