### PR TITLE
feat(ui): add person component and polish styles

### DIFF
--- a/packages/style-dictionary/lib/color-generator.js
+++ b/packages/style-dictionary/lib/color-generator.js
@@ -21,7 +21,7 @@ const getLightnessScale = (min = 26, max = 97, steps = 9) => {
  * Hue is preserved exactly across all shades.
  *
  * @param {string} baseColorStr - An oklch color string, e.g. "oklch(65% 0.22 279.42)"
- * @returns {Record<string, string>} Object with keys "100"-"900" and oklch string values
+ * @returns {Record<string, string>} Object with keys "100"-"900" plus "850" and oklch string values
  */
 const generateOklchScale = (baseColorStr) => {
 	const base = new Color(baseColorStr);
@@ -35,23 +35,24 @@ const generateOklchScale = (baseColorStr) => {
 	const MIN_L = 0.20;
 
 	// Build lightness array: 100-400 evenly from MAX_L to just above baseL,
-	// 500 = baseL, 600-900 evenly from just below baseL to MIN_L
-	const lighterCount = 4; // shades 100-400
-	const darkerCount = 4; // shades 600-900
+	// 500 = baseL, 600-900 evenly from just below baseL to MIN_L.
+	// Keep an extra 850 stop between 800 and 900 for finer dark-range control.
+	const lighterShades = [100, 200, 300, 400];
+	const darkerShades = [600, 700, 800, 850, 900];
+	const lighterCount = lighterShades.length;
+	const darkerCount = darkerShades.length;
 	const lighterStep = (MAX_L - baseL) / lighterCount;
 	const darkerStep = (baseL - MIN_L) / darkerCount;
 
 	const lightnessMap = {};
 	// 100-400: lighter shades
-	for (let i = 0; i < lighterCount; i++) {
-		const shade = (i + 1) * 100; // 100, 200, 300, 400
+	for (const [i, shade] of lighterShades.entries()) {
 		lightnessMap[shade] = MAX_L - i * lighterStep;
 	}
 	// 500: anchor
 	lightnessMap[500] = baseL;
-	// 600-900: darker shades
-	for (let i = 0; i < darkerCount; i++) {
-		const shade = 600 + i * 100; // 600, 700, 800, 900
+	// 600-900: darker shades, including 850
+	for (const [i, shade] of darkerShades.entries()) {
 		lightnessMap[shade] = baseL - (i + 1) * darkerStep;
 	}
 

--- a/packages/style-dictionary/tests/color-generator.test.js
+++ b/packages/style-dictionary/tests/color-generator.test.js
@@ -11,10 +11,10 @@ describe("getLightnessScale", () => {
 });
 
 describe("generateOklchScale", () => {
-	it("should return object with keys 100-900", () => {
+	it("should return object with keys 100-900 plus 850", () => {
 		const scale = generateOklchScale("oklch(65% 0.22 279.42)");
 		const keys = Object.keys(scale);
-		const expected = ["100", "200", "300", "400", "500", "600", "700", "800", "900"];
+		const expected = ["100", "200", "300", "400", "500", "600", "700", "800", "850", "900"];
 		assert.deepStrictEqual(keys, expected);
 	});
 
@@ -32,7 +32,7 @@ describe("generateOklchScale", () => {
 
 	it("should have lightness decreasing from 100 to 900", () => {
 		const scale = generateOklchScale("oklch(65% 0.22 279.42)");
-		const shades = ["100", "200", "300", "400", "500", "600", "700", "800", "900"];
+		const shades = ["100", "200", "300", "400", "500", "600", "700", "800", "850", "900"];
 		for (let i = 0; i < shades.length - 1; i++) {
 			const currentL = parseFloat(scale[shades[i]].match(/oklch\((\d+(\.\d+)?)%/)[1]);
 			const nextL = parseFloat(scale[shades[i + 1]].match(/oklch\((\d+(\.\d+)?)%/)[1]);
@@ -57,7 +57,7 @@ describe("generateOklchScale", () => {
 
 	it("should have evenly spaced lightness steps (perceptual uniformity)", () => {
 		const scale = generateOklchScale("oklch(65% 0.22 279.42)");
-		const shades = ["100", "200", "300", "400", "500", "600", "700", "800", "900"];
+		const shades = ["100", "200", "300", "400", "500", "600", "700", "800", "850", "900"];
 		const lightnesses = shades.map((s) =>
 			parseFloat(scale[s].match(/oklch\((\d+(\.\d+)?)%/)[1]),
 		);
@@ -92,7 +92,7 @@ describe("generateOklchScale", () => {
 	it("should handle achromatic input with chroma 0", () => {
 		const scale = generateOklchScale("oklch(60% 0 0)");
 		const keys = Object.keys(scale);
-		const expected = ["100", "200", "300", "400", "500", "600", "700", "800", "900"];
+		const expected = ["100", "200", "300", "400", "500", "600", "700", "800", "850", "900"];
 		assert.deepStrictEqual(keys, expected);
 
 		// All shades should have chroma 0 (or very close)

--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -977,6 +977,23 @@
           "members": [
             {
               "kind": "field",
+              "name": "_fieldsetDisabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "_handleFormClick",
+              "parameters": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "privacy": "public",
               "type": {
@@ -985,6 +1002,38 @@
               "default": "false",
               "attribute": "disabled",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "form",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "form",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "method",
+              "name": "formDisabledCallback",
+              "parameters": [
+                {
+                  "name": "disabled"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback"
             },
             {
               "kind": "field",
@@ -1035,6 +1084,13 @@
               },
               "default": "false",
               "fieldName": "disabled"
+            },
+            {
+              "name": "form",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "form"
             },
             {
               "name": "href",
@@ -2940,6 +2996,17 @@
             },
             {
               "kind": "field",
+              "name": "direction",
+              "privacy": "public",
+              "type": {
+                "text": "'vertical' | 'horizontal'"
+              },
+              "description": "Direction of the field. Generally want horizontal for checkboxes and radios.",
+              "default": "\"vertical\"",
+              "attribute": "direction"
+            },
+            {
+              "kind": "field",
               "name": "error",
               "privacy": "public",
               "type": {
@@ -2999,24 +3066,26 @@
             },
             {
               "kind": "field",
-              "name": "inlineInput",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
               "name": "label",
               "privacy": "public",
               "type": {
                 "text": "string"
               },
               "default": "\"\"",
-              "attribute": "label"
+              "attribute": "label",
+              "reflects": true
             }
           ],
           "attributes": [
+            {
+              "name": "direction",
+              "type": {
+                "text": "'vertical' | 'horizontal'"
+              },
+              "description": "Direction of the field. Generally want horizontal for checkboxes and radios.",
+              "default": "\"vertical\"",
+              "fieldName": "direction"
+            },
             {
               "name": "error",
               "type": {
@@ -3910,7 +3979,11 @@
             },
             {
               "kind": "field",
-              "name": "_darkQuery"
+              "name": "_darkQuery",
+              "type": {
+                "text": "null"
+              },
+              "default": "null"
             },
             {
               "kind": "field",
@@ -4852,6 +4925,198 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/person/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "module": "src/components/person/person.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/person/person.component.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "GrantCodesPerson",
+          "members": [
+            {
+              "kind": "field",
+              "name": "alt",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "alt"
+            },
+            {
+              "kind": "field",
+              "name": "avatar",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "avatar"
+            },
+            {
+              "kind": "field",
+              "name": "company",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "company"
+            },
+            {
+              "kind": "field",
+              "name": "meta",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "name"
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "attribute": "role"
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"medium\"",
+              "attribute": "size"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "alt",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "fieldName": "alt"
+            },
+            {
+              "name": "avatar",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "fieldName": "avatar"
+            },
+            {
+              "name": "company",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "fieldName": "company"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "fieldName": "name"
+            },
+            {
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "fieldName": "role"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"medium\"",
+              "fieldName": "size"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "grantcodes-person",
+          "customElement": true,
+          "modulePath": "src/components/person/person.component.js",
+          "definitionPath": "src/components/person/person.js"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "GrantCodesPerson",
+          "declaration": {
+            "name": "GrantCodesPerson",
+            "module": "src/components/person/person.component.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/person/person.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "module": "src/components/person/person.component.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "name": "GrantCodesPerson",
+            "module": "src/components/person/person.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "grantcodes-person",
+          "declaration": {
+            "name": "GrantCodesPerson",
+            "module": "/src/components/person/person.component.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/pricing/index.js",
       "declarations": [],
       "exports": [
@@ -5592,12 +5857,7 @@
             }
           ],
           "modulePath": "src/components/tabs/internal/tabs-button.component.js",
-          "definitionPath": "src/components/tabs/internal/tabs-button.js",
-          "cssProperties": [],
-          "cssParts": [],
-          "cssStates": [],
-          "events": [],
-          "slots": []
+          "definitionPath": "src/components/tabs/internal/tabs-button.js"
         }
       ],
       "exports": [
@@ -5645,160 +5905,8 @@
     {
       "kind": "javascript-module",
       "path": "src/components/tabs/internal/tabs-item.component.js",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "GrantCodesTabsItem",
-          "members": [
-            {
-              "kind": "field",
-              "name": "active",
-              "privacy": "public",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "active"
-            },
-            {
-              "kind": "field",
-              "name": "buttonId",
-              "privacy": "public",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "attribute": "buttonId",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "containerId",
-              "privacy": "public",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "attribute": "containerId"
-            },
-            {
-              "kind": "field",
-              "name": "content",
-              "privacy": "public",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "attribute": "content"
-            },
-            {
-              "kind": "field",
-              "name": "index",
-              "privacy": "public",
-              "type": {
-                "text": "number"
-              },
-              "default": "-1",
-              "attribute": "index"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "privacy": "public",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "panelId",
-              "privacy": "public",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "attribute": "panelId"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "active",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "active"
-            },
-            {
-              "name": "buttonId",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "fieldName": "buttonId"
-            },
-            {
-              "name": "containerId",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "fieldName": "containerId"
-            },
-            {
-              "name": "content",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "fieldName": "content"
-            },
-            {
-              "name": "index",
-              "type": {
-                "text": "number"
-              },
-              "default": "-1",
-              "fieldName": "index"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "fieldName": "label"
-            },
-            {
-              "name": "panelId",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "fieldName": "panelId"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "customElement": true,
-          "modulePath": "src/components/tabs/internal/tabs-item.component.js"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "GrantCodesTabsItem",
-          "declaration": {
-            "name": "GrantCodesTabsItem",
-            "module": "src/components/tabs/internal/tabs-item.component.js"
-          }
-        }
-      ]
+      "declarations": [],
+      "exports": []
     },
     {
       "kind": "javascript-module",
@@ -6002,12 +6110,7 @@
             }
           ],
           "modulePath": "src/components/tabs/tab.component.js",
-          "definitionPath": "src/components/tabs/tab.js",
-          "cssProperties": [],
-          "cssParts": [],
-          "cssStates": [],
-          "events": [],
-          "slots": []
+          "definitionPath": "src/components/tabs/tab.js"
         }
       ],
       "exports": [
@@ -6150,9 +6253,25 @@
       "exports": [
         {
           "kind": "js",
+          "name": "GrantCodesTab",
+          "declaration": {
+            "name": "GrantCodesTab",
+            "module": "src/components/tabs/tabs.component.js"
+          }
+        },
+        {
+          "kind": "js",
           "name": "GrantCodesTabs",
           "declaration": {
             "name": "GrantCodesTabs",
+            "module": "src/components/tabs/tabs.component.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "GrantCodesTabsButton",
+          "declaration": {
+            "name": "GrantCodesTabsButton",
             "module": "src/components/tabs/tabs.component.js"
           }
         }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
     "watch": "vite build --watch",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "build": "npm run build-storybook",
+		"build": "run-s cem build-storybook",
     "generate": "plop",
     "cem": "cem analyze --config custom-elements-manifest.config.js --litelement",
     "fix": "run-s fix:lint",

--- a/packages/ui/src/components/person/index.js
+++ b/packages/ui/src/components/person/index.js
@@ -1,0 +1,1 @@
+export * from "./person.js";

--- a/packages/ui/src/components/person/person.component.js
+++ b/packages/ui/src/components/person/person.component.js
@@ -1,0 +1,50 @@
+import { LitElement, html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+import personStyles from "./person.css" with { type: "css" };
+import "../avatar/avatar.js";
+
+export class GrantCodesPerson extends LitElement {
+	static properties = {
+		name: { type: String },
+		role: { type: String },
+		company: { type: String },
+		avatar: { type: String },
+		alt: { type: String },
+		size: { type: String },
+	};
+
+	static styles = [personStyles];
+
+	constructor() {
+		super();
+		this.name = "";
+		this.role = "";
+		this.company = "";
+		this.avatar = "";
+		this.alt = "";
+		this.size = "medium";
+	}
+
+	get meta() {
+		return [this.role, this.company].filter(Boolean).join(", ");
+	}
+
+	render() {
+		const meta = this.meta;
+
+		return html`
+			<div class="person">
+				<grantcodes-avatar
+					src=${ifDefined(this.avatar || undefined)}
+					name=${ifDefined(this.name || undefined)}
+					alt=${ifDefined(this.alt || undefined)}
+					size=${this.size}
+				></grantcodes-avatar>
+				<div class="person__meta">
+					<cite class="person__name">${this.name}</cite>
+					${meta ? html`<span class="person__details">${meta}</span>` : null}
+				</div>
+			</div>
+		`;
+	}
+}

--- a/packages/ui/src/components/person/person.css
+++ b/packages/ui/src/components/person/person.css
@@ -1,0 +1,33 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+:host {
+	display: block;
+}
+
+.person {
+	display: flex;
+	align-items: center;
+	gap: var(--g-spacing-sm);
+}
+
+.person__meta {
+	display: flex;
+	flex-direction: column;
+	gap: var(--g-spacing-xs);
+	min-inline-size: 0;
+}
+
+.person__name {
+	font: var(--g-typography-body-sm-font);
+	font-style: normal;
+	color: var(--g-color-content-default);
+}
+
+.person__details {
+	font: var(--g-typography-body-sm-font);
+	color: var(--g-color-content-subtle);
+}

--- a/packages/ui/src/components/person/person.js
+++ b/packages/ui/src/components/person/person.js
@@ -1,0 +1,8 @@
+import { GrantCodesPerson } from "./person.component.js";
+
+export * from "./person.component.js";
+export default GrantCodesPerson;
+
+if (!customElements.get("grantcodes-person")) {
+	customElements.define("grantcodes-person", GrantCodesPerson);
+}

--- a/packages/ui/src/components/person/person.react.js
+++ b/packages/ui/src/components/person/person.react.js
@@ -1,0 +1,9 @@
+import React from "react";
+import { createComponent } from "@lit/react";
+import { GrantCodesPerson } from "./person.js";
+
+export const Person = createComponent({
+	tagName: "grantcodes-person",
+	elementClass: GrantCodesPerson,
+	react: React,
+});

--- a/packages/ui/src/components/person/person.stories.js
+++ b/packages/ui/src/components/person/person.stories.js
@@ -1,0 +1,34 @@
+import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
+const { events, args, argTypes, template } =
+	getStorybookHelpers("grantcodes-person");
+import "./person.js";
+
+const meta = {
+	title: "Components/Person",
+	component: "grantcodes-person",
+	args: {
+		...args,
+		name: "Tommy Tobasco",
+		role: "Designer",
+		company: "GrantCodes",
+		avatar: "https://placehold.co/160x160",
+		size: "small",
+	},
+	argTypes,
+	render: (storyArgs) => template(storyArgs),
+	parameters: {
+		actions: {
+			handles: events,
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {};
+
+export const Initials = {
+	args: {
+		avatar: undefined,
+	},
+};

--- a/packages/ui/src/components/person/person.test.js
+++ b/packages/ui/src/components/person/person.test.js
@@ -1,0 +1,40 @@
+import { afterEach, describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { cleanup, fixture } from "../../test-utils/index.js";
+import "./person.js";
+
+describe("Person Component", () => {
+	let element;
+
+	afterEach(() => {
+		cleanup(element);
+	});
+
+	it("should render name and details", async () => {
+		element = await fixture("grantcodes-person", {
+			name: "Jane Doe",
+			role: "Designer",
+			company: "GrantCodes",
+		});
+
+		assert.strictEqual(
+			element.shadowRoot.querySelector(".person__name")?.textContent,
+			"Jane Doe",
+		);
+		assert.strictEqual(
+			element.shadowRoot.querySelector(".person__details")?.textContent,
+			"Designer, GrantCodes",
+		);
+	});
+
+	it("should omit details when role and company are missing", async () => {
+		element = await fixture("grantcodes-person", {
+			name: "Jane Doe",
+		});
+
+		assert.equal(
+			element.shadowRoot.querySelector(".person__details"),
+			null,
+		);
+	});
+});

--- a/packages/ui/src/components/tabs/internal/tabs-item.component.js
+++ b/packages/ui/src/components/tabs/internal/tabs-item.component.js
@@ -1,6 +1,11 @@
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
 
+/**
+ * Internal shared base class for tabs primitives.
+ * @internal
+ * @tag grantcodes-tabs-item
+ */
 export class GrantCodesTabsItem extends LitElement {
 	static properties = {
 		active: { type: Boolean },

--- a/packages/ui/src/components/tabs/tabs.component.js
+++ b/packages/ui/src/components/tabs/tabs.component.js
@@ -31,10 +31,10 @@ export class GrantCodesTabs extends LitElement {
 		}
 	}
 
-	/** @type {GrantCodesTab[]} */
+	/** @type {import("./tab.component.js").GrantCodesTab[]} */
 	tabs = [];
 
-	/** @type {GrantCodesTabsButton[]} */
+	/** @type {import("./internal/tabs-button.component.js").GrantCodesTabsButton[]} */
 	tabButtons = [];
 
 	get activeTab() {
@@ -130,3 +130,5 @@ export class GrantCodesTabs extends LitElement {
 		`;
 	}
 }
+
+export { GrantCodesTab, GrantCodesTabsButton };

--- a/packages/ui/src/components/testimonials/testimonials.component.js
+++ b/packages/ui/src/components/testimonials/testimonials.component.js
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import testimonialsStyles from "./testimonials.css" with { type: "css" };
 import "../card/card.js";
-import "../avatar/avatar.js";
+import "../person/person.js";
 
 export class GrantCodesTestimonials extends LitElement {
 	static styles = [testimonialsStyles];
@@ -63,27 +63,13 @@ export class GrantCodesTestimonials extends LitElement {
 											</p>
 										</blockquote>
 										<footer class="testimonials__attribution" slot="footer">
-											${
-												item.avatar
-													? html`<grantcodes-avatar
-														src=${item.avatar}
-														name=${item.name}
-														size="small"
-													></grantcodes-avatar>`
-													: null
-											}
-											<div class="testimonials__meta">
-												<cite class="testimonials__name">${item.name}</cite>
-												${
-													item.role || item.company
-														? html`<span class="testimonials__role">
-															${[item.role, item.company]
-																.filter(Boolean)
-																.join(", ")}
-														</span>`
-														: null
-												}
-											</div>
+											<grantcodes-person
+												name=${item.name ?? ""}
+												role=${item.role ?? ""}
+												company=${item.company ?? ""}
+												avatar=${item.avatar ?? ""}
+												size="small"
+											></grantcodes-person>
 										</footer>
 									</grantcodes-card>
 								</li>

--- a/packages/ui/src/components/testimonials/testimonials.css
+++ b/packages/ui/src/components/testimonials/testimonials.css
@@ -55,29 +55,11 @@
 .testimonials__text {
 	margin: 0;
 	font: var(--g-typography-body-default);
+	font-style: italic;
 	color: var(--g-color-content-default);
 	flex: 1;
 }
 
 .testimonials__attribution {
-	display: flex;
-	align-items: center;
-	gap: var(--g-spacing-sm);
-}
-
-.testimonials__meta {
-	display: flex;
-	flex-direction: column;
-	gap: var(--g-spacing-xs);
-}
-
-.testimonials__name {
-	font: var(--g-typography-body-sm-font);
-	font-style: normal;
-	color: var(--g-color-content-default);
-}
-
-.testimonials__role {
-    font: var(--g-typography-body-sm-font);
-	color: var(--g-color-content-subtle);
+	margin-top: auto;
 }

--- a/packages/ui/src/components/tooltip/tooltip.css
+++ b/packages/ui/src/components/tooltip/tooltip.css
@@ -29,7 +29,7 @@
 	z-index: 100;
 	border-radius: var(--g-border-radius-md);
 	padding: 0.6em 1em;
-	font-size: var(--g-typography-body-sm-font-size);
+	font-size: var(--g-typography-font-size-xs);
 	line-height: 1;
 	color: var(--g-color-primary-900);
 	background-color: var(--g-color-primary-100);

--- a/packages/ui/src/css/elements/media/image.css
+++ b/packages/ui/src/css/elements/media/image.css
@@ -1,3 +1,4 @@
 img {
 	block-size: auto;
+	background-color: var(--g-color-background-subtle);
 }

--- a/packages/ui/src/main.js
+++ b/packages/ui/src/main.js
@@ -21,6 +21,7 @@ export * from "./components/media-text/index.js";
 export * from "./components/newsletter/index.js";
 export * from "./components/notice/index.js";
 export * from "./components/pagination/index.js";
+export * from "./components/person/index.js";
 export * from "./components/pricing/index.js";
 export * from "./components/stats/index.js";
 export * from "./components/tabs/index.js";

--- a/packages/ui/src/react.js
+++ b/packages/ui/src/react.js
@@ -34,6 +34,7 @@ export { MediaText } from "./components/media-text/media-text.react.js";
 export { Newsletter } from "./components/newsletter/newsletter.react.js";
 export { Notice } from "./components/notice/notice.react.js";
 export { Pagination } from "./components/pagination/pagination.react.js";
+export { Person } from "./components/person/person.react.js";
 export { Pricing } from "./components/pricing/pricing.react.js";
 export { Sidebar } from "./components/sidebar/sidebar.react.js";
 export { Stats } from "./components/stats/stats.react.js";


### PR DESCRIPTION
## Summary
- add the new person component and use it in testimonials
- add the 850 style-dictionary shade and update tests
- run CEM during the UI build and regenerate the manifest
- polish tooltip, testimonial, and base image styles

## Verification
- pnpm test:ui
- pnpm test:style-dictionary
- pnpm --filter @grantcodes/ui cem