### PR TITLE
feat(ui, style-dictionary): expand person usage

### DIFF
--- a/packages/style-dictionary/tokens/core/02-semantic/typography.json
+++ b/packages/style-dictionary/tokens/core/02-semantic/typography.json
@@ -32,10 +32,10 @@
 					"value": "calc(1rem * pow({typography.font-scale.default}, -1))"
 				},
 				"xs": {
-					"value": "calc(1rem * pow({typography.font-scale.default}, -0.25))"
+					"value": "calc(1rem * pow({typography.font-scale.default}, -0.5))"
 				},
 				"sm": {
-					"value": "calc(1rem * pow({typography.font-scale.default}, -0.125))"
+					"value": "calc(1rem * pow({typography.font-scale.default}, -0.25))"
 				},
 				"md": {
 					"value": "1rem"

--- a/packages/ui/src/components/person/person.component.js
+++ b/packages/ui/src/components/person/person.component.js
@@ -43,6 +43,7 @@ export class GrantCodesPerson extends LitElement {
 				<div class="person__meta">
 					<cite class="person__name">${this.name}</cite>
 					${meta ? html`<span class="person__details">${meta}</span>` : null}
+					<slot name="description" class="person__description"></slot>
 				</div>
 			</div>
 		`;

--- a/packages/ui/src/components/person/person.css
+++ b/packages/ui/src/components/person/person.css
@@ -22,7 +22,7 @@
 }
 
 .person__name {
-	font: var(--g-typography-body-sm-font);
+	font: var(--g-typography-body-font);
 	font-style: normal;
 	color: var(--g-color-content-default);
 }
@@ -30,4 +30,10 @@
 .person__details {
 	font: var(--g-typography-body-sm-font);
 	color: var(--g-color-content-subtle);
+}
+
+::slotted([slot="description"]) {
+	font: var(--g-typography-body-sm-font);
+	color: var(--g-color-content-subtle);
+	margin-block-start: var(--g-spacing-xs);
 }

--- a/packages/ui/src/components/person/person.stories.js
+++ b/packages/ui/src/components/person/person.stories.js
@@ -1,3 +1,4 @@
+import { html } from "lit";
 import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
 const { events, args, argTypes, template } =
 	getStorybookHelpers("grantcodes-person");
@@ -31,4 +32,28 @@ export const Initials = {
 	args: {
 		avatar: undefined,
 	},
+};
+
+export const WithDescription = {
+	args: {
+		name: "Sam Torres",
+		role: "CTO",
+		company: "Flowbase",
+		avatar: "https://i.pravatar.cc/80?img=12",
+		size: "medium",
+	},
+	render: (storyArgs) => html`
+		<grantcodes-person
+			name="${storyArgs.name}"
+			role="${storyArgs.role}"
+			company="${storyArgs.company}"
+			avatar="${storyArgs.avatar}"
+			size="${storyArgs.size}"
+		>
+			<span slot="description"
+				>Writes about engineering culture, distributed teams, and systems
+				thinking.</span
+			>
+		</grantcodes-person>
+	`,
 };

--- a/packages/ui/src/components/person/person.test.js
+++ b/packages/ui/src/components/person/person.test.js
@@ -37,4 +37,33 @@ describe("Person Component", () => {
 			null,
 		);
 	});
+
+	it("should render content in the description slot", async () => {
+		element = await fixture("grantcodes-person", {
+			name: "Jane Doe",
+		});
+
+		const description = document.createElement("span");
+		description.setAttribute("slot", "description");
+		description.textContent = "A short bio about Jane";
+		element.appendChild(description);
+
+		await element.updateComplete;
+
+		const slot = element.shadowRoot.querySelector(
+			'slot[name="description"]',
+		);
+		assert.ok(slot, "description slot should exist");
+
+		const assignedNodes = slot.assignedNodes({ flatten: true });
+		const hasText = assignedNodes.some(
+			(node) =>
+				node.textContent &&
+				node.textContent.includes("A short bio about Jane"),
+		);
+		assert.ok(
+			hasText,
+			"description slot should contain the projected text",
+		);
+	});
 });

--- a/packages/ui/src/pages/blog-post.stories.js
+++ b/packages/ui/src/pages/blog-post.stories.js
@@ -5,7 +5,7 @@ import "../components/button/button.js";
 import "../components/breadcrumb/breadcrumb.js";
 import "../components/container/container.js";
 import "../components/badge/badge.js";
-import "../components/avatar/avatar.js";
+import "../components/person/person.js";
 import "../components/card/card.js";
 import "../components/cta/cta.js";
 import "../components/footer/footer.js";
@@ -80,7 +80,7 @@ const footerContent = html`
 /**
  * A full blog post page. Demonstrates a reading-focused layout using the
  * container component for column width control, breadcrumb for navigation
- * context, badge for category tagging, avatar for the author byline, and
+ * context, badge for category tagging, person for the author byline, and
  * cards for related posts at the bottom.
  */
 export const Default = {
@@ -131,23 +131,16 @@ export const Default = {
           <div
             style="display: flex; align-items: center; gap: var(--g-spacing-sm); padding-block: var(--g-spacing-md); border-block: 1px solid var(--g-color-border-default);"
           >
-            <grantcodes-avatar
-              src="https://i.pravatar.cc/80?img=12"
+            <grantcodes-person
               name="Sam Torres"
+              avatar="https://i.pravatar.cc/80?img=12"
               size="small"
-            ></grantcodes-avatar>
-            <div>
-              <p
-                style="margin: 0; font: var(--g-typography-body-sm-font); color: var(--g-color-content-default);"
-              >
-                Sam Torres
-              </p>
-              <p
-                style="margin: 0; color: var(--g-color-content-subtle); font-size: var(--g-typography-font-size-xs);"
-              >
-                March 12, 2025 · 8 min read
-              </p>
-            </div>
+            ></grantcodes-person>
+            <span
+              style="color: var(--g-color-content-subtle); font-size: var(--g-typography-font-size-xs);"
+            >
+              March 12, 2025 · 8 min read
+            </span>
           </div>
         </div>
       </div>
@@ -249,24 +242,18 @@ export const Default = {
         </p>
 
         <div
-          style="margin-block-start: var(--g-spacing-xl); padding: var(--g-spacing-md); background: var(--g-color-background-subtle); border-radius: var(--g-border-radius-md); display: flex; align-items: center; gap: var(--g-spacing-md);"
+          style="margin-block-start: var(--g-spacing-xl); padding: var(--g-spacing-md); background: var(--g-color-background-subtle); border-radius: var(--g-border-radius-md);"
         >
-          <grantcodes-avatar
-            src="https://i.pravatar.cc/80?img=12"
+          <grantcodes-person
             name="Sam Torres"
+            avatar="https://i.pravatar.cc/80?img=12"
             size="medium"
-          ></grantcodes-avatar>
-          <div>
-            <p
-              style="margin: 0; font: var(--g-typography-h6-font); color: var(--g-color-content-default);"
+          >
+            <span slot="description"
+              >CTO at Flowbase. Writes about engineering culture, distributed
+              teams, and systems thinking.</span
             >
-              Sam Torres
-            </p>
-            <p style="font: var(--g-typography-body-sm-font);">
-              CTO at Flowbase. Writes about engineering culture, distributed
-              teams, and systems thinking.
-            </p>
-          </div>
+          </grantcodes-person>
         </div>
       </article>
     </grantcodes-container>
@@ -306,15 +293,11 @@ export const Default = {
                   slot="footer"
                   style="display: flex; align-items: center; gap: var(--g-spacing-sm);"
                 >
-                  <grantcodes-avatar
-                    src="${post.author.avatar}"
+                  <grantcodes-person
                     name="${post.author.name}"
+                    avatar="${post.author.avatar}"
                     size="small"
-                  ></grantcodes-avatar>
-                  <span
-                    style="font: var(--g-typography-body-sm-font);"
-                    >${post.author.name}</span
-                  >
+                  ></grantcodes-person>
                 </div>
               </grantcodes-card>
             `,


### PR DESCRIPTION
## Summary
- replace manual avatar/name markup in the blog post story with `grantcodes-person`
- add a `description` slot to `grantcodes-person` with story/test coverage
- widen the small typography token spread for `sm` and `xs`

## Verification
- pnpm test:ui
- pnpm build (packages/style-dictionary)

## Notes
- feature is still at checkpoint/review stage, so this PR is opened as a draft