### PR TITLE
fix(ci): allow release workflow writes

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -8,8 +8,9 @@ on:
 jobs:
   release-please:
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- update the release workflow token permissions for release-please
- allow creating refs and updating pull requests from the workflow

## Verification
- reviewed failing GitHub Actions log for `403 Resource not accessible by integration`
- verified workflow diff in `.github/workflows/create-release.yaml`

## Notes
- this fixes a pre-existing workflow permissions issue, not a regression from PR #126