### PR TITLE
fix(ci): use trusted publishing for npm release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -8,8 +8,9 @@ on:
 jobs:
   release-please:
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -48,13 +49,19 @@ jobs:
         if: ${{ steps.release.outputs['packages/ui--release_created'] }}
         working-directory: packages/ui
         run: pnpm publish  --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ""
 
       - name: Publish @grantcodes/style-dictionary
         if: ${{ steps.release.outputs['packages/style-dictionary--release_created'] }}
         working-directory: packages/style-dictionary
         run: pnpm publish  --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ""
 
       - name: Publish @grantcodes/astro
         if: ${{ steps.release.outputs['packages/astro--release_created'] }}
         working-directory: packages/astro
         run: pnpm publish  --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary
- update release workflow permissions so release-please can write refs and PRs
- stop using token-based npm auth in publish steps
- force publish steps onto trusted publishing / OIDC only

## Verification
- reviewed failing publish run showing OIDC provenance succeeded
- confirmed publish step still had `NODE_AUTH_TOKEN` in the environment
- verified workflow diff in `.github/workflows/create-release.yaml`

## Notes
- this addresses the npm publish failure after moving to trusted publishers
- unrelated local untracked files were not included