### PR TITLE
fix: align package metadata for trusted publishing

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -28,6 +28,14 @@
     "name": "Grant Richmond",
     "url": "https://grant.codes"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/grantcodes/ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/grantcodes/ui/issues"
+  },
+  "homepage": "https://github.com/grantcodes/ui#readme",
   "license": "MIT",
   "dependencies": {
     "@grantcodes/style-dictionary": "^1.5.1",

--- a/packages/style-dictionary/package.json
+++ b/packages/style-dictionary/package.json
@@ -49,12 +49,12 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/grantcodes/style-dictionary.git"
+		"url": "git+https://github.com/grantcodes/ui.git"
 	},
 	"bugs": {
-		"url": "https://github.com/grantcodes/style-dictionary/issues"
+		"url": "https://github.com/grantcodes/ui/issues"
 	},
-	"homepage": "https://github.com/grantcodes/style-dictionary#readme",
+	"homepage": "https://github.com/grantcodes/ui#readme",
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "2.1.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,14 @@
   "module": "src/main.js",
   "types": "src/types.d.ts",
   "author": "grantcodes",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/grantcodes/ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/grantcodes/ui/issues"
+  },
+  "homepage": "https://github.com/grantcodes/ui#readme",
   "exports": {
     ".": {
       "types": "./src/types.d.ts",


### PR DESCRIPTION
## Summary
- align published package repository metadata to the ui monorepo
- add missing repository, bugs, and homepage fields for ui and astro
- fix style-dictionary metadata to match npm trusted publishing requirements

## Why
- npm trusted publishing expects package repository metadata to exactly match the GitHub repository used by the workflow