### PR TITLE
ci: update setup-node for trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Setup pnpm
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         name: Setup node
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Setup Turbo cache
         uses: actions/cache@v4
@@ -46,10 +46,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Setup pnpm
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         name: Setup node
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Setup Turbo cache
         uses: actions/cache@v4

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -26,11 +26,12 @@ jobs:
         name: Setup pnpm
         if: ${{ steps.release.outputs.releases_created }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         name: Setup node
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
         if: ${{ steps.release.outputs.releases_created }}
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- update GitHub Actions workflows to use actions/setup-node@v6
- move workflow Node versions from 22 to 24
- disable package-manager cache in the release workflow

## Why
- npm trusted publishing now requires npm 11.5.1+ and Node 22.14+
- current Node 24 releases already bundle a compatible npm 11.x version, so no extra npm install step is needed

## Testing
- not run (workflow/config change only)