### PR TITLE
refactor: share container usage across astro and ui

### DIFF
--- a/packages/astro/src/blocks/accordion.astro
+++ b/packages/astro/src/blocks/accordion.astro
@@ -3,6 +3,7 @@ import {
   GrantCodesAccordion,
   GrantCodesAccordionItem,
 } from '@grantcodes/ui/components/accordion/index.js'
+import { GrantCodesContainer } from '@grantcodes/ui/components/container/index.js'
 
 interface AccordionItem {
   title: string
@@ -18,7 +19,7 @@ const { items } = Astro.props
 ---
 
 <div class="accordion">
-  <div class="container">
+  <GrantCodesContainer align="prose">
     <GrantCodesAccordion client:visible>
       {items.map((item) => (
         <GrantCodesAccordionItem title={item.title}>
@@ -28,18 +29,12 @@ const { items } = Astro.props
         </GrantCodesAccordionItem>
       ))}
     </GrantCodesAccordion>
-  </div>
+  </GrantCodesContainer>
 </div>
 
 <style>
   .accordion {
-    padding: 2rem 0;
-  }
-
-  .container {
-    width: 100%;
-    max-width: 65ch;
-    margin: 0 auto;
-    padding: 0 1rem;
+    padding-block: var(--g-spacing-2xl);
+    font: var(--g-typography-body-font);
   }
 </style>

--- a/packages/astro/src/blocks/cards.astro
+++ b/packages/astro/src/blocks/cards.astro
@@ -1,5 +1,6 @@
 ---
 import { GrantCodesCard } from '@grantcodes/ui/components/card/index.js'
+import { GrantCodesContainer } from '@grantcodes/ui/components/container/index.js'
 
 interface CardItem {
   title: string
@@ -16,7 +17,7 @@ const { cards } = Astro.props
 ---
 
 <div class="cards">
-  <div class="container">
+  <GrantCodesContainer align="wide">
     <div class="cards__grid">
       {cards.map((card) => (
         <a href={card.href || '#'} class="card-link">
@@ -28,24 +29,18 @@ const { cards } = Astro.props
         </a>
       ))}
     </div>
-  </div>
+  </GrantCodesContainer>
 </div>
 
 <style>
   .cards {
-    padding: 3rem 0;
-  }
-
-  .container {
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 0 1rem;
+    padding-block: var(--g-spacing-2xl);
   }
 
   .cards__grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 1.5rem;
+    gap: var(--g-spacing-xl);
   }
 
   .card-link {
@@ -56,7 +51,7 @@ const { cards } = Astro.props
   }
 
   .card-link:hover {
-    transform: translateY(-2px);
+    translate: 0 -2px;
   }
 
   .card__image {
@@ -67,16 +62,7 @@ const { cards } = Astro.props
   }
 
   .card__title {
-    margin: 0 0 0.5rem;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--g-theme-color-content-default, #111827);
-  }
-
-  .card__description {
     margin: 0;
-    font-size: 0.875rem;
-    color: var(--g-theme-color-content-default, #6b7280);
-    line-height: 1.5;
+    font: var(--g-typography-h4-font);
   }
 </style>

--- a/packages/astro/src/blocks/gallery.astro
+++ b/packages/astro/src/blocks/gallery.astro
@@ -1,6 +1,7 @@
 ---
 import { GrantCodesGallery } from '@grantcodes/ui/components/gallery/index.js'
 import { GrantCodesGalleryImage } from '@grantcodes/ui/components/gallery/index.js'
+import { GrantCodesContainer } from '@grantcodes/ui/components/container/index.js'
 
 interface GalleryImage {
   src: string
@@ -25,29 +26,23 @@ const { images, filmstrip = false, marquee = false } = Astro.props
       ))}
     </GrantCodesGallery>
   ) : (
-    <div class="container">
+    <GrantCodesContainer align="wide">
       <GrantCodesGallery>
         {images.map((image) => (
           <GrantCodesGalleryImage src={image.src} alt={image.alt || ''} />
         ))}
       </GrantCodesGallery>
-    </div>
+    </GrantCodesContainer>
   )}
 </div>
 
 <style>
   .gallery {
-    padding-block: 3rem;
+    padding-block: var(--g-spacing-2xl);
   }
 
   .gallery--filmstrip {
-    padding-block: 2rem;
+    padding-block: var(--g-spacing-xl);
     overflow: hidden;
-  }
-
-  .container {
-    max-inline-size: 1400px;
-    margin-inline: auto;
-    padding-inline: 1rem;
   }
 </style>

--- a/packages/astro/src/blocks/text.astro
+++ b/packages/astro/src/blocks/text.astro
@@ -1,4 +1,5 @@
 ---
+import { GrantCodesContainer } from '@grantcodes/ui/components/container/index.js'
 import { marked } from 'marked'
 
 interface Props {
@@ -11,13 +12,14 @@ const htmlContent = marked.parse(content)
 ---
 
 <div class="text-block">
-  <Fragment set:html={htmlContent} />
+  <GrantCodesContainer align="prose">
+    <Fragment set:html={htmlContent} />
+  </GrantCodesContainer>
 </div>
 
 <style>
   .text-block {
-    max-width: 65ch;
-    margin: 0 auto;
-    padding: 2rem 1rem;
+    padding-block: var(--g-spacing-2xl);
+    font: var(--g-typography-body-font);
   }
 </style>

--- a/packages/ui/src/components/app-bar/app-bar.component.js
+++ b/packages/ui/src/components/app-bar/app-bar.component.js
@@ -10,8 +10,8 @@ export class GrantCodesAppBar extends LitElement {
 	static styles = [focusRingStyles, appBarStyles];
 
 	static properties = {
-		sticky: { type: Boolean },
-		transparent: { type: Boolean },
+		sticky: { type: Boolean, reflect: true },
+		transparent: { type: Boolean, reflect: true },
 		_mobileMenuOpen: { type: Boolean, state: true },
 	};
 

--- a/packages/ui/src/components/app-bar/app-bar.test.js
+++ b/packages/ui/src/components/app-bar/app-bar.test.js
@@ -55,6 +55,14 @@ describe("App Bar Component", () => {
 		assert.ok(appBar, "Should have sticky class");
 	});
 
+	it("should reflect sticky to the host attribute", async () => {
+		element = await fixture("grantcodes-app-bar", {
+			sticky: true,
+		});
+
+		assert.ok(element.hasAttribute("sticky"), "Should reflect sticky attribute");
+	});
+
 	it("should apply transparent class when transparent", async () => {
 		element = await fixture("grantcodes-app-bar", {
 			transparent: true,
@@ -62,6 +70,17 @@ describe("App Bar Component", () => {
 
 		const appBar = element.shadowRoot.querySelector(".app-bar--transparent");
 		assert.ok(appBar, "Should have transparent class");
+	});
+
+	it("should reflect transparent to the host attribute", async () => {
+		element = await fixture("grantcodes-app-bar", {
+			transparent: true,
+		});
+
+		assert.ok(
+			element.hasAttribute("transparent"),
+			"Should reflect transparent attribute",
+		);
 	});
 
 	it("should have logo slot", async () => {

--- a/packages/ui/src/components/cta/cta.component.js
+++ b/packages/ui/src/components/cta/cta.component.js
@@ -1,6 +1,7 @@
 import { LitElement, html } from "lit";
 import ctaStyles from "./cta.css" with { type: "css" };
 import "../button/button.js";
+import "../container/container.js";
 
 export class GrantCodesCta extends LitElement {
 	static styles = [ctaStyles];
@@ -69,7 +70,7 @@ export class GrantCodesCta extends LitElement {
 		const secondary = this._secondaryAction;
 		return html`
 			<section class="cta">
-				<div class="cta__container">
+				<grantcodes-container align="prose">
 					${
 						this.eyebrow
 							? html`<p class="cta__eyebrow">${this.eyebrow}</p>`
@@ -101,7 +102,7 @@ export class GrantCodesCta extends LitElement {
 							`
 							: null
 					}
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/cta/cta.css
+++ b/packages/ui/src/components/cta/cta.css
@@ -10,13 +10,7 @@
 
 .cta {
 	padding-block: var(--g-spacing-3xl);
-	padding-inline: var(--g-spacing-md);
 	background: var(--g-color-background-subtle);
-}
-
-.cta__container {
-	max-width: 65ch;
-	margin: 0 auto;
 }
 
 :host([align="center"]) .cta {

--- a/packages/ui/src/components/feature-list/feature-list.component.js
+++ b/packages/ui/src/components/feature-list/feature-list.component.js
@@ -3,6 +3,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import * as icons from "lucide-static";
 import featureListStyles from "./feature-list.css" with { type: "css" };
 import "../icon/icon.js";
+import "../container/container.js";
 
 export class GrantCodesFeatureList extends LitElement {
 	static styles = [featureListStyles];
@@ -67,7 +68,7 @@ export class GrantCodesFeatureList extends LitElement {
 		const items = this._items;
 		return html`
 			<section class="feature-list">
-				<div class="feature-list__container">
+				<grantcodes-container>
 					${
 						this.title
 							? html`<h2 class="feature-list__title">${this.title}</h2>`
@@ -123,7 +124,7 @@ export class GrantCodesFeatureList extends LitElement {
 							`,
 						)}
 					</ul>
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/feature-list/feature-list.css
+++ b/packages/ui/src/components/feature-list/feature-list.css
@@ -10,12 +10,6 @@
 
 .feature-list {
 	padding-block: var(--g-spacing-3xl);
-	padding-inline: var(--g-spacing-md);
-}
-
-.feature-list__container {
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .feature-list__title {

--- a/packages/ui/src/components/footer/footer.component.js
+++ b/packages/ui/src/components/footer/footer.component.js
@@ -1,6 +1,7 @@
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
 import footerStyles from "./footer.css" with { type: "css" };
+import "../container/container.js";
 
 export class GrantCodesFooter extends LitElement {
 	static styles = [footerStyles];
@@ -22,7 +23,7 @@ export class GrantCodesFooter extends LitElement {
 	render() {
 		return html`
 			<footer class="footer">
-				<div class="footer__container">
+				<grantcodes-container align="wide">
 					<div class="footer__columns" style="--footer-columns: ${this.columns}">
 						<slot></slot>
 					</div>
@@ -31,7 +32,7 @@ export class GrantCodesFooter extends LitElement {
 					<div class="footer__bottom">
 						<slot name="bottom"></slot>
 					</div>
-				</div>
+				</grantcodes-container>
 			</footer>
 		`;
 	}

--- a/packages/ui/src/components/footer/footer.css
+++ b/packages/ui/src/components/footer/footer.css
@@ -12,15 +12,9 @@
 
 .footer {
 	margin-block-start: auto;
+	padding-block: var(--g-spacing-2xl) var(--g-spacing-xl);
 	border-block-start: 1px solid var(--g-color-border-subtle);
 	background-color: var(--g-color-background-subtle);
-}
-
-.footer__container {
-	padding-block: var(--g-spacing-2xl) var(--g-spacing-xl);
-	padding-inline: var(--g-spacing-md);
-	max-inline-size: 1400px;
-	margin-inline: auto;
 }
 
 .footer__columns {

--- a/packages/ui/src/components/footer/footer.test.js
+++ b/packages/ui/src/components/footer/footer.test.js
@@ -86,7 +86,7 @@ describe("Footer Component", () => {
 
 	it("should have footer container", async () => {
 		element = await fixture("grantcodes-footer");
-		const container = element.shadowRoot.querySelector(".footer__container");
+		const container = element.shadowRoot.querySelector("grantcodes-container");
 		assert.ok(container, "Footer container should exist");
 	});
 

--- a/packages/ui/src/components/logo-cloud/logo-cloud.component.js
+++ b/packages/ui/src/components/logo-cloud/logo-cloud.component.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import logoCloudStyles from "./logo-cloud.css" with { type: "css" };
+import "../container/container.js";
 
 export class GrantCodesLogoCloud extends LitElement {
 	static styles = [logoCloudStyles];
@@ -35,7 +36,7 @@ export class GrantCodesLogoCloud extends LitElement {
 		const logos = this._logos;
 		return html`
 			<section class="logo-cloud">
-				<div class="logo-cloud__container">
+				<grantcodes-container>
 					${
 						this.title
 							? html`<p class="logo-cloud__title">${this.title}</p>`
@@ -74,7 +75,7 @@ export class GrantCodesLogoCloud extends LitElement {
 							`,
 						)}
 					</ul>
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/logo-cloud/logo-cloud.css
+++ b/packages/ui/src/components/logo-cloud/logo-cloud.css
@@ -10,14 +10,8 @@
 
 .logo-cloud {
 	padding-block: var(--g-spacing-2xl);
-	padding-inline: var(--g-spacing-md);
 	border-top: 1px solid var(--g-color-border-default);
 	border-bottom: 1px solid var(--g-color-border-default);
-}
-
-.logo-cloud__container {
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .logo-cloud__title {

--- a/packages/ui/src/components/pricing/pricing.component.js
+++ b/packages/ui/src/components/pricing/pricing.component.js
@@ -1,6 +1,7 @@
 import { LitElement, html } from "lit";
 import pricingStyles from "./pricing.css" with { type: "css" };
 import "../button/button.js";
+import "../container/container.js";
 
 export class GrantCodesPricing extends LitElement {
 	static styles = [pricingStyles];
@@ -43,7 +44,7 @@ export class GrantCodesPricing extends LitElement {
 		const tiers = this._tiers;
 		return html`
 			<section class="pricing">
-				<div class="pricing__container">
+				<grantcodes-container>
 					${
 						this.title
 							? html`<h2 class="pricing__title">${this.title}</h2>`
@@ -112,7 +113,7 @@ export class GrantCodesPricing extends LitElement {
 							`,
 						)}
 					</ul>
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/pricing/pricing.css
+++ b/packages/ui/src/components/pricing/pricing.css
@@ -10,12 +10,6 @@
 
 .pricing {
 	padding-block: var(--g-spacing-3xl);
-	padding-inline: var(--g-spacing-md);
-}
-
-.pricing__container {
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .pricing__title {

--- a/packages/ui/src/components/stats/stats.component.js
+++ b/packages/ui/src/components/stats/stats.component.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import statsStyles from "./stats.css" with { type: "css" };
+import "../container/container.js";
 
 export class GrantCodesStats extends LitElement {
 	static styles = [statsStyles];
@@ -41,7 +42,7 @@ export class GrantCodesStats extends LitElement {
 		const items = this._items;
 		return html`
 			<section class="stats">
-				<div class="stats__container">
+				<grantcodes-container>
 					${
 						this.title
 							? html`<h2 class="stats__title">${this.title}</h2>`
@@ -66,7 +67,7 @@ export class GrantCodesStats extends LitElement {
 							`,
 						)}
 					</ul>
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/stats/stats.css
+++ b/packages/ui/src/components/stats/stats.css
@@ -10,13 +10,7 @@
 
 .stats {
 	padding-block: var(--g-spacing-3xl);
-	padding-inline: var(--g-spacing-md);
 	background: var(--g-color-background-subtle);
-}
-
-.stats__container {
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .stats__title {

--- a/packages/ui/src/components/testimonials/testimonials.component.js
+++ b/packages/ui/src/components/testimonials/testimonials.component.js
@@ -2,6 +2,7 @@ import { LitElement, html } from "lit";
 import testimonialsStyles from "./testimonials.css" with { type: "css" };
 import "../card/card.js";
 import "../person/person.js";
+import "../container/container.js";
 
 export class GrantCodesTestimonials extends LitElement {
 	static styles = [testimonialsStyles];
@@ -43,7 +44,7 @@ export class GrantCodesTestimonials extends LitElement {
 		const items = this._items;
 		return html`
 			<section class="testimonials">
-				<div class="testimonials__container">
+				<grantcodes-container>
 					${
 						this.title
 							? html`<h2 class="testimonials__title">${this.title}</h2>`
@@ -76,7 +77,7 @@ export class GrantCodesTestimonials extends LitElement {
 							`,
 						)}
 					</ul>
-				</div>
+				</grantcodes-container>
 			</section>
 		`;
 	}

--- a/packages/ui/src/components/testimonials/testimonials.css
+++ b/packages/ui/src/components/testimonials/testimonials.css
@@ -10,12 +10,6 @@
 
 .testimonials {
 	padding-block: var(--g-spacing-3xl);
-	padding-inline: var(--g-spacing-md);
-}
-
-.testimonials__container {
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .testimonials__title {


### PR DESCRIPTION
## Summary
- reflect app bar sticky and transparent booleans back to host attributes
- switch Astro block wrappers to shared GrantCodesContainer usage and tokenized spacing
- replace duplicated section container wrappers in UI components with grantcodes-container

## Commits
- fix(ui): reflect app bar boolean attrs
- refactor(astro): use shared containers in blocks
- refactor(ui): use shared containers in sections

## Testing
- node --import @lit-labs/ssr-dom-shim/register-css-hook.js --test --test-concurrency=1 src/components/app-bar/app-bar.test.js
- npm run test:unit