### PR TITLE
fix(ui): handle app bar nav overflow

### DIFF
--- a/packages/ui/src/components/app-bar/app-bar.css
+++ b/packages/ui/src/components/app-bar/app-bar.css
@@ -214,6 +214,35 @@
 		align-items: center;
 		gap: var(--g-spacing-xs, 0.25rem);
 		flex: 1;
+		min-inline-size: 0;
+		overflow-x: auto;
+		flex-wrap: nowrap;
+		-webkit-overflow-scrolling: touch;
+		-webkit-mask-image: linear-gradient(
+			to right,
+			black calc(100% - 1.5rem),
+			transparent
+		);
+		mask-image: linear-gradient(
+			to right,
+			black calc(100% - 1.5rem),
+			transparent
+		);
+		scrollbar-width: thin;
+		scrollbar-color: var(--g-color-border-default) transparent;
+	}
+
+	.app-bar__nav::-webkit-scrollbar {
+		height: 4px;
+	}
+
+	.app-bar__nav::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.app-bar__nav::-webkit-scrollbar-thumb {
+		background: var(--g-color-border-default);
+		border-radius: 2px;
 	}
 
 	/* Reset mobile-open styles at desktop — nav is always inline */
@@ -225,10 +254,22 @@
 		box-shadow: none;
 		animation: none;
 		flex-direction: row;
+		overflow-x: auto;
+		-webkit-mask-image: linear-gradient(
+			to right,
+			black calc(100% - 1.5rem),
+			transparent
+		);
+		mask-image: linear-gradient(
+			to right,
+			black calc(100% - 1.5rem),
+			transparent
+		);
 	}
 
 	.app-bar__actions {
 		order: 3;
+		flex-shrink: 0;
 	}
 
 	.app-bar__menu-button {
@@ -238,6 +279,11 @@
 	/* Overlay is never visible on desktop */
 	.app-bar__overlay--visible {
 		display: none;
+	}
+
+	::slotted(ul),
+	::slotted(div[slot="nav"]) {
+		flex-shrink: 0;
 	}
 }
 

--- a/packages/ui/src/components/app-bar/app-bar.stories.js
+++ b/packages/ui/src/components/app-bar/app-bar.stories.js
@@ -101,6 +101,43 @@ export const Transparent = {
 };
 
 /**
+ * Many nav items demonstrating horizontal scroll overflow on desktop.
+ * When the viewport is wide enough for desktop mode but too narrow for all
+ * items, the nav becomes horizontally scrollable with a subtle fade affordance
+ * at the right edge and styled thin scrollbars.
+ */
+export const ManyNavItems = {
+	render: () => html`
+		<grantcodes-app-bar>
+			<a slot="logo" href="/">MyApp</a>
+			<div slot="nav">
+				<grantcodes-nav-link><a href="/">Home</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/about">About</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/features">Features</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/pricing">Pricing</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/docs">Docs</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/blog">Blog</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/changelog">Changelog</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/api">API</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/support">Support</a></grantcodes-nav-link>
+				<grantcodes-nav-link><a href="/status">Status</a></grantcodes-nav-link>
+			</div>
+			<div slot="actions">
+				<grantcodes-button>Sign In</grantcodes-button>
+			</div>
+		</grantcodes-app-bar>
+	`,
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Resize the viewport to see the nav items become horizontally scrollable on desktop with a right-edge fade affordance and thin scrollbar.",
+			},
+		},
+	},
+};
+
+/**
  * App bar with multiple action buttons.
  */
 export const WithMultipleActions = {


### PR DESCRIPTION
## Summary
- allow desktop app bar nav to scroll horizontally when many items overflow
- add a subtle right-edge fade and thin scrollbar styling for the desktop nav
- add a Storybook example with many nav items for visual verification

## Testing
- node --import @lit-labs/ssr-dom-shim/register-css-hook.js --test --test-concurrency=1 src/components/app-bar/app-bar.test.js