### PR TITLE
chore(ui): regenerate custom elements manifest

### DIFF
--- a/packages/ui/custom-elements.json
+++ b/packages/ui/custom-elements.json
@@ -234,7 +234,8 @@
               },
               "description": "Whether the app bar is sticky",
               "default": "false",
-              "attribute": "sticky"
+              "attribute": "sticky",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -245,7 +246,8 @@
               },
               "description": "Whether the app bar has transparent background",
               "default": "false",
-              "attribute": "transparent"
+              "attribute": "transparent",
+              "reflects": true
             }
           ],
           "events": [


### PR DESCRIPTION
## Summary
- regenerate the UI custom elements manifest after the recent app bar metadata changes
- include reflected attribute metadata for app bar boolean properties

## Testing
- pnpm cem