### PR TITLE
fix(ui): raise sticky app bar layer

### DIFF
--- a/packages/ui/src/components/app-bar/app-bar.css
+++ b/packages/ui/src/components/app-bar/app-bar.css
@@ -14,7 +14,7 @@
 	background-color: var(--g-color-background-default);
 	border-block-end: 1px solid var(--g-color-border-default);
 	position: relative;
-	z-index: 100;
+ 	z-index: 1000;
 }
 
 :host([sticky]),


### PR DESCRIPTION
## Summary
- raise the app bar z-index so sticky usage stays above page content
- keep the change narrowly scoped to the existing app bar CSS layer value

## Testing
- not run (single CSS value change)