### PR TITLE
fix(astro): tighten block card and prop handling

### DIFF
--- a/packages/astro/src/blocks/cards.astro
+++ b/packages/astro/src/blocks/cards.astro
@@ -20,13 +20,23 @@ const { cards } = Astro.props
   <GrantCodesContainer align="wide">
     <div class="cards__grid">
       {cards.map((card) => (
-        <a href={card.href || '#'} class="card-link">
-          <GrantCodesCard>
-            {card.image && <img slot="header" src={card.image} alt="" class="card__image" />}
-            <h3 class="card__title">{card.title}</h3>
-            {card.description && <p class="card__description">{card.description}</p>}
-          </GrantCodesCard>
-        </a>
+        card.href ? (
+          <a href={card.href} class="card-link">
+            <GrantCodesCard>
+              {card.image && <img slot="header" src={card.image} alt="" loading="lazy" class="card__image" />}
+              <h3 class="card__title">{card.title}</h3>
+              {card.description && <p class="card__description">{card.description}</p>}
+            </GrantCodesCard>
+          </a>
+        ) : (
+          <div class="card-link">
+            <GrantCodesCard>
+              {card.image && <img slot="header" src={card.image} alt="" loading="lazy" class="card__image" />}
+              <h3 class="card__title">{card.title}</h3>
+              {card.description && <p class="card__description">{card.description}</p>}
+            </GrantCodesCard>
+          </div>
+        )
       ))}
     </div>
   </GrantCodesContainer>
@@ -50,8 +60,10 @@ const { cards } = Astro.props
     color: inherit;
   }
 
-  .card-link:hover {
-    translate: 0 -2px;
+  @media (prefers-reduced-motion: no-preference) {
+    .card-link:hover {
+      translate: 0 -2px;
+    }
   }
 
   .card__image {

--- a/packages/astro/src/blocks/countdown.astro
+++ b/packages/astro/src/blocks/countdown.astro
@@ -29,6 +29,6 @@ const {
   minutes-label={minutesLabel}
   seconds-label={secondsLabel}
   past-message={pastMessage}
-  show-seconds={showSeconds || undefined}
+  show-seconds={showSeconds ? true : undefined}
   client:only
 ></GrantCodesCountdown>

--- a/packages/astro/src/blocks/hero.astro
+++ b/packages/astro/src/blocks/hero.astro
@@ -19,7 +19,7 @@ const { title, subtitle, button, href, size, center } = Astro.props
   button={button}
   href={href}
   size={size}
-  center={center || undefined}
+  center={center ? true : undefined}
 >
   <slot />
 </GrantCodesHero>

--- a/packages/astro/src/blocks/media-text.astro
+++ b/packages/astro/src/blocks/media-text.astro
@@ -20,6 +20,6 @@ const { title, text, media, reverse = false, cta } = Astro.props
   title={title}
   text={text}
   media={JSON.stringify(media)}
-  reverse={reverse || undefined}
+  reverse={reverse ? true : undefined}
   cta={cta ? JSON.stringify(cta) : undefined}
 ></GrantCodesMediaText>


### PR DESCRIPTION
## Summary
- avoid fake card links when no href is provided
- lazy-load card images and respect reduced motion for card hover lift
- make boolean prop emission explicit in hero, media-text, and countdown blocks

## Testing
- not run (Astro template-only changes)