### PR TITLE
fix: adjust app bar layer and clickable cards

### DIFF
--- a/packages/astro/src/blocks/cards.astro
+++ b/packages/astro/src/blocks/cards.astro
@@ -22,7 +22,7 @@ const { cards } = Astro.props
       {cards.map((card) => (
         card.href ? (
           <a href={card.href} class="card-link">
-            <GrantCodesCard>
+            <GrantCodesCard class="is-clickable">
               {card.image && <img slot="header" src={card.image} alt="" loading="lazy" class="card__image" />}
               <h3 class="card__title">{card.title}</h3>
               {card.description && <p class="card__description">{card.description}</p>}

--- a/packages/ui/src/components/app-bar/app-bar.css
+++ b/packages/ui/src/components/app-bar/app-bar.css
@@ -8,13 +8,13 @@
 	display: block;
 	container-type: inline-size;
 	container-name: app-bar;
+	z-index: 1000;
 }
 
 .app-bar {
 	background-color: var(--g-color-background-default);
 	border-block-end: 1px solid var(--g-color-border-default);
 	position: relative;
- 	z-index: 1000;
 }
 
 :host([sticky]),


### PR DESCRIPTION
## Summary
- move the app bar z-index from the internal shadow DOM element to the host
- add `is-clickable` to linked Astro cards so clickable card styles apply

## Testing
- pnpm --filter @grantcodes/ui exec node --import @lit-labs/ssr-dom-shim/register-css-hook.js --test --test-concurrency=1 src/components/app-bar/app-bar.test.js
- pnpm test