### PR TITLE
fix(astro): generate CEM-based constructor typings

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -13,7 +13,9 @@
   "scripts": {
     "build": "echo 'No build step required — source-based imports'",
     "fix": "echo 'No lint configured'",
-    "test": "tsx --test test/smoke.test.js test/ssr-constructor-diagnostics.test.js test/og-images.test.js"
+    "gen:props": "tsx scripts/generate-astro-typings-from-cem.ts",
+    "pretest": "tsx scripts/generate-astro-typings-from-cem.ts",
+    "test": "tsx --test test/smoke.test.js test/ssr-constructor-diagnostics.test.js test/og-images.test.js test/astro-check-typings.test.js"
   },
   "keywords": [
     "astro",

--- a/packages/astro/scripts/generate-astro-typings-from-cem.ts
+++ b/packages/astro/scripts/generate-astro-typings-from-cem.ts
@@ -1,0 +1,424 @@
+// generate-astro-typings-from-cem.ts
+//
+// Reads packages/ui/custom-elements.json and emits
+// packages/astro/src/generated/ui-component-props.d.ts
+//
+// The generated file provides Astro-compatible type declarations for direct
+// SSR constructor imports from @grantcodes/ui/components/ path.
+//
+// Run: pnpm --filter @grantcodes/astro exec tsx scripts/generate-astro-typings-from-cem.ts
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, "..");
+const MONOREPO_ROOT = resolve(PACKAGE_ROOT, "..", "..");
+const CEM_PATH = resolve(MONOREPO_ROOT, "packages", "ui", "custom-elements.json");
+const OUTPUT_PATH = resolve(PACKAGE_ROOT, "src", "generated", "ui-component-props.d.ts");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CemAttribute {
+  name: string;
+  type?: { text?: string };
+  description?: string;
+  default?: string;
+  fieldName?: string;
+}
+
+interface CemClassDeclaration {
+  kind: "class";
+  name: string;
+  tagName?: string;
+  customElement?: boolean;
+  definitionPath?: string;
+  modulePath?: string;
+  attributes?: CemAttribute[];
+  members?: Array<{
+    kind: "field" | "method";
+    name: string;
+    privacy?: string;
+    type?: { text?: string };
+    attribute?: string;
+    default?: string;
+  }>;
+}
+
+interface CemExport {
+  kind: "js" | "custom-element-definition";
+  name: string;
+  declaration?: {
+    name: string;
+    module: string;
+  };
+}
+
+interface CemModule {
+  kind: "javascript-module";
+  path: string;
+  declarations: CemClassDeclaration[];
+  exports: CemExport[];
+}
+
+interface CemDocument {
+  schemaVersion: string;
+  modules: CemModule[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Map CEM type.text to a safe TypeScript type string.
+function cemTypeToTs(typeText: string | undefined): string {
+  if (!typeText || typeText.trim() === "") return "string";
+
+  const t = typeText.trim();
+
+  // Exact match for simple types
+  const simple: Record<string, string> = {
+    boolean: "boolean",
+    string: "string",
+    number: "number",
+    object: "Record<string, unknown>",
+    null: "unknown",
+    undefined: "undefined",
+  };
+  if (simple[t] !== undefined) return simple[t];
+
+  // JS String built-in
+  if (t === "String") return "string";
+
+  // Array patterns
+  if (t.endsWith("[]")) return "unknown[]";
+  if (t === "Array" || t === "any[]") return "unknown[]";
+
+  // Literal unions like 'primary' | 'success' — keep as-is (valid TS)
+  if (/^'[^']*'(?:\s*\|\s*'[^']*')*$/.test(t)) return t;
+
+  // Complex unions that aren't literal unions — unsafe
+  if (t.includes("|") && !t.includes("'")) return "unknown";
+
+  // DOM type references
+  if (/^HTMLElement/.test(t) || /^HTML[A-Z]/.test(t)) return "unknown";
+  if (t.includes("TemplateResult") || t.includes("CustomEvent")) return "unknown";
+
+  // Simple PascalCase identifiers — treat as unknown (likely a complex type)
+  if (/^[A-Z][A-Za-z0-9_]+$/.test(t)) return "unknown";
+
+  return "unknown";
+}
+
+// Clean a CEM member name: strip surrounding double quotes that Lit uses for
+// hyphenated property names (e.g. `"days-label"` → `days-label`).
+function cleanMemberName(raw: string): string {
+  let s = raw.trim();
+  if (s.startsWith('"') && s.endsWith('"')) s = s.slice(1, -1);
+  return s;
+}
+
+// Derive constructor-import props from a CEM class declaration.
+//
+// Astro templates pass props as JS property names (camelCase from Lit @property
+// fields), NOT HTML attribute names (kebab-case).  We therefore prioritise
+// CEM `members` over `attributes`, and add kebab-case aliases only when they
+// differ from the JS property name, so consumers can use either style.
+function deriveProps(decl: CemClassDeclaration): Record<string, string> {
+  const props: Record<string, string> = {};
+  const seen = new Set<string>();
+
+  // 1. Public member fields → JS property names (constructor-import DX)
+  if (decl.members) {
+    for (const m of decl.members) {
+      if (m.kind !== "field") continue;
+      if (m.privacy !== "public") continue;
+
+      const propName = cleanMemberName(m.name);
+      if (!propName || propName.startsWith("_") || seen.has(propName)) continue;
+      seen.add(propName);
+      props[propName] = cemTypeToTs(m.type?.text);
+
+      // Also emit the kebab-case HTML attribute name as an optional alias
+      // when it differs from the JS property name.
+      const attrName = m.attribute ? cleanMemberName(m.attribute) : undefined;
+      if (attrName && attrName !== propName && !seen.has(attrName)) {
+        seen.add(attrName);
+        props[attrName] = cemTypeToTs(m.type?.text);
+      }
+    }
+  }
+
+  // 2. Attributes not already covered by a member → still expose them
+  if (decl.attributes) {
+    for (const attr of decl.attributes) {
+      const name = cleanMemberName(attr.name);
+      if (!name || name.startsWith("_") || seen.has(name)) continue;
+
+      // If the attribute's fieldName matches a member we already processed,
+      // skip it — we already have the JS property name.
+      if (attr.fieldName && seen.has(cleanMemberName(attr.fieldName))) continue;
+      seen.add(name);
+      props[name] = cemTypeToTs(attr.type?.text);
+    }
+  }
+
+  return props;
+}
+
+// Escape a prop name for use in a .d.ts interface (kebab-case gets quoted).
+function escapePropName(name: string): string {
+  if (name.includes("-")) return `"${name}"`;
+  return name;
+}
+
+// Normalize a CEM module path (stripping leading "/").
+function normPath(p: string): string {
+  return p.replace(/^\/+/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  console.log(`[generate] Reading CEM: ${CEM_PATH}`);
+  const cemRaw = readFileSync(CEM_PATH, "utf-8");
+  const cem: CemDocument = JSON.parse(cemRaw);
+
+  // ---- Build lookup maps ----
+
+  // Map from module path -> module
+  const modByPath = new Map<string, CemModule>();
+  for (const mod of cem.modules) {
+    if (mod.kind === "javascript-module") {
+      modByPath.set(normPath(mod.path), mod);
+    }
+  }
+
+  // Map from class declaration name -> CemClassDeclaration
+  const classByName = new Map<string, CemClassDeclaration>();
+  for (const mod of cem.modules) {
+    if (mod.kind !== "javascript-module") continue;
+    for (const decl of mod.declarations) {
+      if (decl.kind === "class" && decl.customElement) {
+        classByName.set(decl.name, decl);
+      }
+    }
+  }
+
+  // ---- Resolve exports of each index.js module ----
+
+  // For a given module, recursively resolve all named export names
+  // (skipping "*" wildcard re-exports by following them).
+  function resolveExports(modPath: string): Set<string> {
+    const result = new Set<string>();
+    const visited = new Set<string>();
+    const queue = [normPath(modPath)];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      const mod = modByPath.get(current);
+      if (!mod) continue;
+
+      for (const exp of mod.exports) {
+        if (exp.kind !== "js") continue;
+
+        if (exp.name === "*") {
+          // Follow the wildcard to the target module
+          if (exp.declaration?.module) {
+            queue.push(normPath(exp.declaration.module));
+          }
+        } else if (exp.name === "default") {
+          // "default" export: follow to the class it references
+          if (exp.declaration?.name && classByName.has(exp.declaration.name)) {
+            result.add(exp.declaration.name);
+          }
+        } else {
+          // Named export (e.g. "GrantCodesButton")
+          result.add(exp.name);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  // ---- Collect public entrypoints ----
+
+  interface ComponentEntry {
+    importSpec: string;
+    className: string;
+    props: Record<string, string>;
+    isPrimary: boolean; // whether this class is the default export
+  }
+
+  const entries: ComponentEntry[] = [];
+
+  for (const mod of cem.modules) {
+    if (mod.kind !== "javascript-module") continue;
+    const p = normPath(mod.path);
+
+    // Only public entrypoints under src/components/*/index.js
+    if (!/^src\/components\/[^/]+\/index\.js$/.test(p)) continue;
+
+    // Skip internal modules
+    if (/\/internal\//.test(p)) continue;
+
+    const importSpec = p.replace(/^src\/components\//, "@grantcodes/ui/components/");
+
+    // Resolve all exported names from this module
+    const exportedNames = resolveExports(p);
+
+    if (exportedNames.size === 0) continue;
+
+    // Determine the default export class name — only when the outer entrypoint
+    // module itself exports `default`.  Do NOT fall back to a single named
+    // export: many components (button, app-bar, pagination, …) use wildcard
+    // re-exports without a default, and claiming a default they don't have
+    // misleads consumers.
+    let defaultClassName: string | undefined;
+    for (const exp of mod.exports) {
+      if (exp.kind === "js" && exp.name === "default") {
+        if (exp.declaration?.name && exportedNames.has(exp.declaration.name)) {
+          defaultClassName = exp.declaration.name;
+        }
+      }
+    }
+
+    for (const className of exportedNames) {
+      const decl = classByName.get(className);
+      if (!decl) {
+        console.warn(`[generate] WARNING: class "${className}" referenced by ${p} but not found in CEM declarations`);
+        continue;
+      }
+      entries.push({
+        importSpec,
+        className,
+        props: deriveProps(decl),
+        isPrimary: className === defaultClassName,
+      });
+    }
+  }
+
+  // ---- Generate output ----
+
+  // Collect ALL unique props across all components for the IntrinsicAttributes
+  // augmentation (see rationale below).
+  const allGlobalProps = new Map<string, string>();
+  for (const entry of entries) {
+    for (const [key, tsType] of Object.entries(entry.props)) {
+      if (!allGlobalProps.has(key)) {
+        allGlobalProps.set(key, tsType);
+      }
+    }
+  }
+  // Add common HTML global attributes that users pass in Astro templates
+  // but which are not derived from the CEM (they are added to every element
+  // via Astro's static analysis / JSX).
+  const htmlGlobals: Record<string, string> = {
+    class: "string",
+    id: "string",
+    style: "string | Record<string, unknown>",
+    slot: "string",
+    title: "string",
+    lang: "string",
+    hidden: "boolean | string",
+    tabindex: "number | string",
+  };
+  for (const [key, tsType] of Object.entries(htmlGlobals)) {
+    if (!allGlobalProps.has(key)) {
+      allGlobalProps.set(key, tsType);
+    }
+  }
+
+  const lines: string[] = [
+    "// -------------------------------------------------------------------------",
+    "// Auto-generated from packages/ui/custom-elements.json",
+    "// Do not edit by hand. Regenerate with:",
+    "//   pnpm --filter @grantcodes/astro exec tsx scripts/generate-astro-typings-from-cem.ts",
+    "// -------------------------------------------------------------------------",
+    "",
+    "// No top-level imports — this file must be fully self-contained so TypeScript",
+    "// can resolve it regardless of module-resolution mode.",
+    "",
+    "// Astro's JSX type system checks framework-component props against an",
+    "// intersection of the component's own type AND JSX.IntrinsicAttributes.",
+    "// IntrinsicAttributes is very narrow by default, so valid Lit-element",
+    "// props (disabled, previousHref, ...) would fail the intersection.",
+    "// We augment IntrinsicAttributes with every known component prop so the",
+    "// intersection succeeds. Each prop is optional, so HTML elements that",
+    "// do not support a given prop are unaffected (their own type does not",
+    "// include it and IntrinsicAttributes is additive).",
+    'declare namespace astroHTML.JSX {',
+    '  interface IntrinsicAttributes {',
+  ];
+  // Emit all known component props into IntrinsicAttributes
+  for (const [key, tsType] of [...allGlobalProps.entries()].sort()) {
+    lines.push(`    ${escapePropName(key)}?: ${tsType};`);
+  }
+  lines.push("  }");
+  lines.push("}");
+  lines.push("");
+  lines.push("// -------------------------------------------------------------------------");
+  lines.push("// Component type declarations");
+  lines.push("// -------------------------------------------------------------------------");
+  lines.push("");
+
+  // Group by importSpec
+  const grouped = new Map<string, ComponentEntry[]>();
+  for (const entry of entries) {
+    if (!grouped.has(entry.importSpec)) grouped.set(entry.importSpec, []);
+    grouped.get(entry.importSpec)!.push(entry);
+  }
+
+  for (const [importSpec, group] of [...grouped.entries()].sort()) {
+    lines.push(`declare module "${importSpec}" {`);
+    lines.push("");
+
+    for (const entry of group) {
+      const propsName = `${entry.className.replace(/^GrantCodes/, "")}Props`;
+      const keys = Object.keys(entry.props);
+
+      lines.push(`  export interface ${propsName} {`);
+      if (keys.length === 0) {
+        lines.push("    [key: string]: unknown;");
+      } else {
+        for (const key of keys) {
+          lines.push(`    ${escapePropName(key)}?: ${entry.props[key]};`);
+        }
+      }
+      lines.push("  }");
+      lines.push("");
+
+      lines.push(`  export function ${entry.className}(props: ${propsName} & import("astro").AstroBuiltinAttributes): any;`);
+      lines.push("");
+    }
+
+    // Default export — only emit when the entrypoint actually provides one
+    const hasDefault = group.some((g) => g.isPrimary);
+    if (hasDefault) {
+      const primary = group.find((g) => g.isPrimary)!;
+      lines.push(`  export default ${primary.className};`);
+    }
+
+    // Named exports
+    for (const entry of group) {
+      lines.push(`  export { ${entry.className} };`);
+    }
+    lines.push("}");
+    lines.push("");
+  }
+
+  writeFileSync(OUTPUT_PATH, lines.join("\n"), "utf-8");
+  console.log(`[generate] Wrote ${OUTPUT_PATH}`);
+  console.log(`[generate] ${entries.length} constructors across ${grouped.size} modules`);
+}
+
+main();

--- a/packages/astro/src/generated/ui-component-props.d.ts
+++ b/packages/astro/src/generated/ui-component-props.d.ts
@@ -1,0 +1,675 @@
+// -------------------------------------------------------------------------
+// Auto-generated from packages/ui/custom-elements.json
+// Do not edit by hand. Regenerate with:
+//   pnpm --filter @grantcodes/astro exec tsx scripts/generate-astro-typings-from-cem.ts
+// -------------------------------------------------------------------------
+
+// No top-level imports — this file must be fully self-contained so TypeScript
+// can resolve it regardless of module-resolution mode.
+
+// Astro's JSX type system checks framework-component props against an
+// intersection of the component's own type AND JSX.IntrinsicAttributes.
+// IntrinsicAttributes is very narrow by default, so valid Lit-element
+// props (disabled, previousHref, ...) would fail the intersection.
+// We augment IntrinsicAttributes with every known component prop so the
+// intersection succeeds. Each prop is optional, so HTML elements that
+// do not support a given prop are unaffected (their own type does not
+// include it and IntrinsicAttributes is additive).
+declare namespace astroHTML.JSX {
+  interface IntrinsicAttributes {
+    action?: string;
+    active?: boolean;
+    align?: string;
+    alt?: string;
+    avatar?: string;
+    button?: string;
+    "button-label"?: string;
+    buttonId?: string;
+    buttonLabel?: string;
+    caption?: string;
+    center?: boolean;
+    class?: string;
+    collapsed?: boolean;
+    collapsible?: boolean;
+    columns?: number;
+    company?: string;
+    containerId?: string;
+    content?: string;
+    cta?: string;
+    current?: boolean;
+    "days-label"?: string;
+    description?: string;
+    direction?: 'vertical' | 'horizontal';
+    "directions-url"?: string;
+    disabled?: boolean;
+    disclaimer?: string;
+    dismissable?: boolean;
+    dismissible?: boolean;
+    duration?: number;
+    error?: string;
+    eyebrow?: string;
+    form?: string;
+    fullscreenOnDrag?: boolean;
+    hasFooter?: boolean;
+    hasHeader?: boolean;
+    height?: number;
+    help?: string;
+    hidden?: boolean | string;
+    "hours-label"?: string;
+    href?: string;
+    id?: string;
+    index?: number;
+    initials?: string;
+    items?: string;
+    label?: string;
+    lang?: string;
+    language?: string;
+    lat?: string;
+    layout?: string;
+    lng?: string;
+    logos?: string;
+    media?: string;
+    method?: string;
+    "minutes-label"?: string;
+    name?: string;
+    "next-href"?: string;
+    nextHref?: string;
+    nopad?: boolean;
+    open?: boolean;
+    page?: number;
+    pages?: number;
+    panelId?: string;
+    "past-message"?: string;
+    placeholder?: string;
+    placement?: string;
+    position?: 'left' | 'right';
+    "previous-href"?: string;
+    previousHref?: string;
+    "primary-action"?: string;
+    primaryAction?: string;
+    reverse?: boolean;
+    role?: string;
+    "secondary-action"?: string;
+    secondaryAction?: string;
+    "seconds-label"?: string;
+    separator?: string;
+    "show-seconds"?: boolean;
+    size?: string;
+    slot?: string;
+    src?: string;
+    sticky?: boolean;
+    style?: string | Record<string, unknown>;
+    subtitle?: string;
+    tabindex?: number | string;
+    target?: string;
+    text?: string;
+    theme?: string;
+    thumbnail?: string;
+    tiers?: string;
+    title?: string;
+    transparent?: boolean;
+    type?: string;
+    value?: string;
+    variant?: 'primary' | 'success' | 'warning' | 'error' | 'info' | 'neutral';
+    width?: number;
+    zoom?: number;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Component type declarations
+// -------------------------------------------------------------------------
+
+declare module "@grantcodes/ui/components/accordion/index.js" {
+
+  export interface AccordionProps {
+    [key: string]: unknown;
+  }
+
+  export function GrantCodesAccordion(props: AccordionProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface AccordionItemProps {
+    open?: boolean;
+    title?: string;
+  }
+
+  export function GrantCodesAccordionItem(props: AccordionItemProps & import("astro").AstroBuiltinAttributes): any;
+
+  export default GrantCodesAccordion;
+  export { GrantCodesAccordion };
+  export { GrantCodesAccordionItem };
+}
+
+declare module "@grantcodes/ui/components/app-bar/index.js" {
+
+  export interface AppBarProps {
+    sticky?: boolean;
+    transparent?: boolean;
+  }
+
+  export function GrantCodesAppBar(props: AppBarProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesAppBar };
+}
+
+declare module "@grantcodes/ui/components/avatar/index.js" {
+
+  export interface AvatarProps {
+    alt?: string;
+    initials?: string;
+    name?: string;
+    size?: string;
+    src?: string;
+  }
+
+  export function GrantCodesAvatar(props: AvatarProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesAvatar };
+}
+
+declare module "@grantcodes/ui/components/badge/index.js" {
+
+  export interface BadgeProps {
+    variant?: 'primary' | 'success' | 'warning' | 'error' | 'info' | 'neutral';
+  }
+
+  export function GrantCodesBadge(props: BadgeProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesBadge };
+}
+
+declare module "@grantcodes/ui/components/breadcrumb/index.js" {
+
+  export interface BreadcrumbProps {
+    separator?: string;
+  }
+
+  export function GrantCodesBreadcrumb(props: BreadcrumbProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface BreadcrumbItemProps {
+    current?: boolean;
+    href?: string;
+  }
+
+  export function GrantCodesBreadcrumbItem(props: BreadcrumbItemProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesBreadcrumb };
+  export { GrantCodesBreadcrumbItem };
+}
+
+declare module "@grantcodes/ui/components/button-group/index.js" {
+
+  export interface ButtonGroupProps {
+    [key: string]: unknown;
+  }
+
+  export function GrantCodesButtonGroup(props: ButtonGroupProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesButtonGroup };
+}
+
+declare module "@grantcodes/ui/components/button/index.js" {
+
+  export interface ButtonProps {
+    disabled?: boolean;
+    form?: string;
+    href?: string;
+    name?: string;
+    type?: string;
+    value?: string;
+  }
+
+  export function GrantCodesButton(props: ButtonProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesButton };
+}
+
+declare module "@grantcodes/ui/components/card/index.js" {
+
+  export interface CardProps {
+    hasFooter?: boolean;
+    hasHeader?: boolean;
+  }
+
+  export function GrantCodesCard(props: CardProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesCard };
+}
+
+declare module "@grantcodes/ui/components/code-preview/index.js" {
+
+  export interface CodePreviewProps {
+    language?: string;
+    theme?: string;
+  }
+
+  export function GrantCodesCodePreview(props: CodePreviewProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesCodePreview };
+}
+
+declare module "@grantcodes/ui/components/container/index.js" {
+
+  export interface ContainerProps {
+    align?: string;
+    nopad?: boolean;
+  }
+
+  export function GrantCodesContainer(props: ContainerProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesContainer };
+}
+
+declare module "@grantcodes/ui/components/countdown/index.js" {
+
+  export interface CountdownProps {
+    "days-label"?: string;
+    "hours-label"?: string;
+    "minutes-label"?: string;
+    "past-message"?: string;
+    "seconds-label"?: string;
+    "show-seconds"?: boolean;
+    target?: string;
+  }
+
+  export function GrantCodesCountdown(props: CountdownProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesCountdown };
+}
+
+declare module "@grantcodes/ui/components/cta/index.js" {
+
+  export interface CtaProps {
+    align?: string;
+    eyebrow?: string;
+    primaryAction?: string;
+    "primary-action"?: string;
+    secondaryAction?: string;
+    "secondary-action"?: string;
+    text?: string;
+    title?: string;
+  }
+
+  export function GrantCodesCta(props: CtaProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesCta };
+}
+
+declare module "@grantcodes/ui/components/dialog/index.js" {
+
+  export interface DialogProps {
+    dismissible?: boolean;
+    open?: boolean;
+  }
+
+  export function GrantCodesDialog(props: DialogProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesDialog };
+}
+
+declare module "@grantcodes/ui/components/dropdown/index.js" {
+
+  export interface DropdownProps {
+    open?: boolean;
+    placement?: string;
+  }
+
+  export function GrantCodesDropdown(props: DropdownProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface DropdownItemProps {
+    disabled?: boolean;
+  }
+
+  export function GrantCodesDropdownItem(props: DropdownItemProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesDropdown };
+  export { GrantCodesDropdownItem };
+}
+
+declare module "@grantcodes/ui/components/dropzone/index.js" {
+
+  export interface DropzoneProps {
+    fullscreenOnDrag?: boolean;
+  }
+
+  export function GrantCodesDropzone(props: DropzoneProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesDropzone };
+}
+
+declare module "@grantcodes/ui/components/feature-list/index.js" {
+
+  export interface FeatureListProps {
+    columns?: number;
+    items?: string;
+    subtitle?: string;
+    title?: string;
+  }
+
+  export function GrantCodesFeatureList(props: FeatureListProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesFeatureList };
+}
+
+declare module "@grantcodes/ui/components/footer/index.js" {
+
+  export interface FooterColumnProps {
+    [key: string]: unknown;
+  }
+
+  export function GrantCodesFooterColumn(props: FooterColumnProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface FooterProps {
+    columns?: number;
+  }
+
+  export function GrantCodesFooter(props: FooterProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesFooterColumn };
+  export { GrantCodesFooter };
+}
+
+declare module "@grantcodes/ui/components/form-field/index.js" {
+
+  export interface FormFieldProps {
+    direction?: 'vertical' | 'horizontal';
+    error?: string;
+    help?: string;
+    label?: string;
+  }
+
+  export function GrantCodesFormField(props: FormFieldProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesFormField };
+}
+
+declare module "@grantcodes/ui/components/gallery/index.js" {
+
+  export interface GalleryProps {
+    variant?: string;
+  }
+
+  export function GrantCodesGallery(props: GalleryProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface GalleryImageProps {
+    alt?: string;
+    caption?: string;
+    height?: number;
+    src?: string;
+    thumbnail?: string;
+    width?: number;
+  }
+
+  export function GrantCodesGalleryImage(props: GalleryImageProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesGallery };
+  export { GrantCodesGalleryImage };
+}
+
+declare module "@grantcodes/ui/components/hero/index.js" {
+
+  export interface HeroProps {
+    button?: string;
+    center?: boolean;
+    href?: string;
+    size?: string;
+    subtitle?: string;
+    title?: string;
+  }
+
+  export function GrantCodesHero(props: HeroProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesHero };
+}
+
+declare module "@grantcodes/ui/components/icon/index.js" {
+
+  export interface IconProps {
+    [key: string]: unknown;
+  }
+
+  export function GrantCodesIcon(props: IconProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesIcon };
+}
+
+declare module "@grantcodes/ui/components/loading/index.js" {
+
+  export interface LoadingProps {
+    [key: string]: unknown;
+  }
+
+  export function GrantCodesLoading(props: LoadingProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesLoading };
+}
+
+declare module "@grantcodes/ui/components/logo-cloud/index.js" {
+
+  export interface LogoCloudProps {
+    logos?: string;
+    title?: string;
+  }
+
+  export function GrantCodesLogoCloud(props: LogoCloudProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesLogoCloud };
+}
+
+declare module "@grantcodes/ui/components/map/index.js" {
+
+  export interface MapProps {
+    "directions-url"?: string;
+    height?: string;
+    label?: string;
+    lat?: string;
+    lng?: string;
+    zoom?: number;
+  }
+
+  export function GrantCodesMap(props: MapProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesMap };
+}
+
+declare module "@grantcodes/ui/components/media-text/index.js" {
+
+  export interface MediaTextProps {
+    cta?: string;
+    media?: string;
+    reverse?: boolean;
+    text?: string;
+    title?: string;
+  }
+
+  export function GrantCodesMediaText(props: MediaTextProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesMediaText };
+}
+
+declare module "@grantcodes/ui/components/newsletter/index.js" {
+
+  export interface NewsletterProps {
+    action?: string;
+    buttonLabel?: string;
+    "button-label"?: string;
+    disclaimer?: string;
+    method?: string;
+    placeholder?: string;
+    text?: string;
+    title?: string;
+  }
+
+  export function GrantCodesNewsletter(props: NewsletterProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesNewsletter };
+}
+
+declare module "@grantcodes/ui/components/notice/index.js" {
+
+  export interface NoticeProps {
+    dismissable?: boolean;
+    title?: string;
+    variant?: string;
+  }
+
+  export function GrantCodesNotice(props: NoticeProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesNotice };
+}
+
+declare module "@grantcodes/ui/components/pagination/index.js" {
+
+  export interface PaginationProps {
+    nextHref?: string;
+    "next-href"?: string;
+    page?: number;
+    pages?: number;
+    previousHref?: string;
+    "previous-href"?: string;
+  }
+
+  export function GrantCodesPagination(props: PaginationProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesPagination };
+}
+
+declare module "@grantcodes/ui/components/person/index.js" {
+
+  export interface PersonProps {
+    alt?: string;
+    avatar?: string;
+    company?: string;
+    name?: string;
+    role?: string;
+    size?: string;
+  }
+
+  export function GrantCodesPerson(props: PersonProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesPerson };
+}
+
+declare module "@grantcodes/ui/components/pricing/index.js" {
+
+  export interface PricingProps {
+    subtitle?: string;
+    tiers?: string;
+    title?: string;
+  }
+
+  export function GrantCodesPricing(props: PricingProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesPricing };
+}
+
+declare module "@grantcodes/ui/components/sidebar/index.js" {
+
+  export interface SidebarProps {
+    collapsed?: boolean;
+    collapsible?: boolean;
+    position?: 'left' | 'right';
+    width?: string;
+  }
+
+  export function GrantCodesSidebar(props: SidebarProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesSidebar };
+}
+
+declare module "@grantcodes/ui/components/stats/index.js" {
+
+  export interface StatsProps {
+    columns?: number;
+    items?: string;
+    title?: string;
+  }
+
+  export function GrantCodesStats(props: StatsProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesStats };
+}
+
+declare module "@grantcodes/ui/components/tabs/index.js" {
+
+  export interface TabsProps {
+    label?: string;
+  }
+
+  export function GrantCodesTabs(props: TabsProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface TabProps {
+    active?: boolean;
+    buttonId?: string;
+    containerId?: string;
+    content?: string;
+    index?: number;
+    label?: string;
+    panelId?: string;
+  }
+
+  export function GrantCodesTab(props: TabProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface TabsButtonProps {
+    active?: boolean;
+    buttonId?: string;
+    containerId?: string;
+    content?: string;
+    index?: number;
+    label?: string;
+    panelId?: string;
+  }
+
+  export function GrantCodesTabsButton(props: TabsButtonProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesTabs };
+  export { GrantCodesTab };
+  export { GrantCodesTabsButton };
+}
+
+declare module "@grantcodes/ui/components/testimonials/index.js" {
+
+  export interface TestimonialsProps {
+    items?: string;
+    layout?: string;
+    title?: string;
+  }
+
+  export function GrantCodesTestimonials(props: TestimonialsProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesTestimonials };
+}
+
+declare module "@grantcodes/ui/components/toast/index.js" {
+
+  export interface ToastProps {
+    dismissible?: boolean;
+    duration?: number;
+    position?: 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+    title?: string;
+    variant?: 'info' | 'success' | 'warning' | 'error';
+  }
+
+  export function GrantCodesToast(props: ToastProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface ToastContainerProps {
+    position?: 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+  }
+
+  export function GrantCodesToastContainer(props: ToastContainerProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesToast };
+  export { GrantCodesToastContainer };
+}
+
+declare module "@grantcodes/ui/components/tooltip/index.js" {
+
+  export interface TooltipProps {
+    description?: string;
+    label?: string;
+  }
+
+  export function GrantCodesTooltip(props: TooltipProps & import("astro").AstroBuiltinAttributes): any;
+
+  export { GrantCodesTooltip };
+}

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration } from "astro";
 import { getViteConfig } from "./vite-config.js";
 import type { AstroOgImagesOptions } from "./og-images.js";
 import { getOgHooks, resolveOgOptions } from "./og-images.js";
 import { resolveTheme, type UiColorScheme, type UiThemeName } from "./themes.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TYPES_PATH = resolve(__dirname, "generated", "ui-component-props.d.ts");
 
 export interface UiOptions {
 	theme?: UiThemeName;
@@ -34,7 +40,7 @@ export default function integration(options?: UiOptions): AstroIntegration {
 				});
 				updateConfig({ vite: getViteConfig() });
 			},
-			"astro:config:done": ({ config }) => {
+			"astro:config:done": ({ config, injectTypes }) => {
 				const noExternal = config.vite?.resolve?.noExternal;
 				if (
 					Array.isArray(noExternal) &&
@@ -42,6 +48,19 @@ export default function integration(options?: UiOptions): AstroIntegration {
 				) {
 					console.warn(
 						"[@grantcodes/astro] WARNING: Your astro.config.mjs has `resolve.noExternal` including `@grantcodes/ui`, which duplicates integration-managed `ssr.noExternal`. Remove `resolve.noExternal` to avoid unexpected behavior."
+					);
+				}
+				// Inject generated type declarations for UI component SSR constructor imports
+				try {
+					const typesContent = readFileSync(TYPES_PATH, "utf-8");
+					injectTypes({
+						filename: "grantcodes-ui-component-props.d.ts",
+						content: typesContent,
+					});
+				} catch (err) {
+					console.warn(
+						"[@grantcodes/astro] WARNING: Could not load generated UI component types; SSR constructor imports may lack prop checking.",
+						err,
 					);
 				}
 			},

--- a/packages/astro/test/astro-check-typings.test.js
+++ b/packages/astro/test/astro-check-typings.test.js
@@ -1,0 +1,282 @@
+/**
+ * astro-check-typings.test.js
+ *
+ * Verifies that the generated UI component type declarations (injected via
+ * injectTypes) make `astro check` accept valid component props and reject
+ * invalid ones.
+ *
+ * Uses the same temp-project pattern as smoke.test.js.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const monorepoRoot = path.resolve(packageRoot, "..", "..");
+
+// --------------------------------------------------------------------------
+// Helpers (same pattern as smoke.test.js)
+// --------------------------------------------------------------------------
+
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function sanitizePkg(pkgPath, overrides) {
+  const pkgJsonPath = path.join(pkgPath, "package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  if (pkg.dependencies) {
+    for (const [dep, replacement] of Object.entries(overrides)) {
+      if (pkg.dependencies[dep]) {
+        pkg.dependencies[dep] = replacement;
+      }
+    }
+  }
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2));
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("@grantcodes/astro astro check typings", () => {
+  it("passes valid component props and rejects invalid ones", () => {
+    const tempDir = path.join("/tmp", `astro-check-typings-${Date.now()}`);
+
+    try {
+      // ---- 1. Copy local packages ----
+      const localPkgs = path.join(tempDir, ".local-packages");
+      const astroPkg = path.join(localPkgs, "astro");
+      const uiPkg = path.join(localPkgs, "ui");
+      const styleDictPkg = path.join(localPkgs, "style-dictionary");
+
+      copyDirSync(packageRoot, astroPkg);
+      copyDirSync(
+        path.resolve(monorepoRoot, "packages", "ui"),
+        uiPkg,
+      );
+      copyDirSync(
+        path.resolve(monorepoRoot, "packages", "style-dictionary"),
+        styleDictPkg,
+      );
+
+      sanitizePkg(astroPkg, {
+        "@grantcodes/ui": `file:${uiPkg}`,
+        "@grantcodes/style-dictionary": `file:${styleDictPkg}`,
+      });
+      sanitizePkg(uiPkg, {
+        "@grantcodes/style-dictionary": `file:${styleDictPkg}`,
+      });
+
+      // ---- 2. Create project ----
+      fs.mkdirSync(path.join(tempDir, "src", "pages"), { recursive: true });
+
+      // package.json
+      fs.writeFileSync(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "astro-check-typings",
+            type: "module",
+            dependencies: {
+              astro: "^6.0.0",
+              "@grantcodes/astro": `file:${astroPkg}`,
+              "@grantcodes/ui": `file:${uiPkg}`,
+              "@astrojs/check": "^0.9.0",
+              typescript: "^5.0.0",
+              lit: "^3.2.0",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      // tsconfig.json – required by astro check
+      fs.writeFileSync(
+        path.join(tempDir, "tsconfig.json"),
+        JSON.stringify(
+          {
+            extends: "astro/tsconfigs/base",
+          },
+          null,
+          2,
+        ),
+      );
+
+      // astro.config.mjs
+      fs.writeFileSync(
+        path.join(tempDir, "astro.config.mjs"),
+        [
+          `import { defineConfig } from 'astro/config';`,
+          `import ui from '@grantcodes/astro';`,
+          `export default defineConfig({ integrations: [ui()] });`,
+        ].join("\n"),
+      );
+
+      // ---- 3. Positive fixture: valid props that should pass astro check ----
+      fs.writeFileSync(
+        path.join(tempDir, "src", "pages", "positive.astro"),
+        [
+          "---",
+          "import { GrantCodesButton } from '@grantcodes/ui/components/button/index.js';",
+          "import { GrantCodesPagination } from '@grantcodes/ui/components/pagination/index.js';",
+          "import { GrantCodesAccordionItem } from '@grantcodes/ui/components/accordion/index.js';",
+          "---",
+          "<html>",
+          "  <body>",
+          // Button with valid props
+          '    <GrantCodesButton disabled href="/test">Works</GrantCodesButton>',
+          // Pagination with camelCase property-style props (constructor DX)
+          "    <GrantCodesPagination previousHref='/prev' nextHref='/next' page={1} pages={5} />",
+          // AccordionItem with valid props
+          '    <GrantCodesAccordionItem open title="FAQ">Content</GrantCodesAccordionItem>',
+          "  </body>",
+          "</html>",
+          "",
+        ].join("\n"),
+      );
+
+      // ---- 4. Negative fixture: invalid prop that should fail astro check ----
+      fs.writeFileSync(
+        path.join(tempDir, "src", "pages", "negative.astro"),
+        [
+          "---",
+          "import { GrantCodesButton } from '@grantcodes/ui/components/button/index.js';",
+          "---",
+          "<html>",
+          "  <body>",
+          // nonexistentProp is not in ButtonProps, AstroBaseAttrs, or AstroBuiltinAttributes
+          '    <GrantCodesButton nonexistentProp="oops">Should Fail</GrantCodesButton>',
+          "  </body>",
+          "</html>",
+          "",
+        ].join("\n"),
+      );
+
+      // ---- 5. Known-prop-on-wrong-constructor fixture ----
+      //
+      // A CEM-derived prop that belongs to one component (here `page` from
+      // PaginationProps) is used on a *different* component
+      // (GrantCodesButton).  This does NOT error because the prop is
+      // declared in the global `IntrinsicAttributes` augmentation, making
+      // it additive across all components.
+      //
+      // This is an intentional tradeoff: the augmentation approach makes
+      // valid Lit-element props pass type-checking when used on their own
+      // component, at the cost of being permissively available on every
+      // component.  A truly unknown prop (nonexistentProp) is still
+      // rejected.  If per-component strictness is needed later, the
+      // augmentation could be narrowed.
+      //
+      // This fixture exists to document and guard the current behaviour.
+      // eslint-disable-next-line no-unused-expressions
+      fs.writeFileSync(
+        path.join(tempDir, "src", "pages", "wrong-constructor-known-prop.astro"),
+        [
+          "---",
+          "import { GrantCodesButton } from '@grantcodes/ui/components/button/index.js';",
+          "---",
+          "<html>",
+          "  <body>",
+          // "page" is a Pagination prop, used here on Button as a known
+          // tradeoff — must NOT produce a type error.
+          "    <GrantCodesButton page={1}>Known-wide-prop</GrantCodesButton>",
+          "  </body>",
+          "</html>",
+          "",
+        ].join("\n"),
+      );
+
+      // ---- 6. Install dependencies ----
+      execSync("npm install", {
+        cwd: tempDir,
+        stdio: "pipe",
+        encoding: "utf8",
+        timeout: 300000,
+      });
+
+      // ---- 7. Run astro check ----
+      let checkStdout = "";
+      let checkStderr = "";
+      let checkExitCode = 0;
+
+      try {
+        const result = execSync("npx astro check 2>&1", {
+          cwd: tempDir,
+          stdio: "pipe",
+          encoding: "utf8",
+          timeout: 180000,
+        });
+        checkStdout = result.stdout || "";
+        checkStderr = result.stderr || "";
+      } catch (e) {
+        checkStdout = e.stdout || "";
+        checkStderr = e.stderr || "";
+        checkExitCode = e.status;
+      }
+
+      const combinedOutput = checkStdout + checkStderr;
+
+      console.log(`[astro-check] exit code: ${checkExitCode}`);
+      console.log(`[astro-check] stdout:\n${checkStdout.slice(0, 2000)}`);
+      if (checkStderr) {
+        console.log(`[astro-check] stderr:\n${checkStderr.slice(0, 1000)}`);
+      }
+
+      // ---- 8. Assertions ----
+
+      // Positive fixture: no type errors for valid prop usage
+      const positiveHasError =
+        combinedOutput.includes("positive.astro") &&
+        (combinedOutput.includes("error") || combinedOutput.includes("Error"));
+      assert.ok(
+        !positiveHasError,
+        `positive.astro should have NO type errors but got:\n${combinedOutput}`,
+      );
+
+      // Negative fixture: type error reported for invalid prop
+      const negativeHasError =
+        combinedOutput.includes("negative.astro") &&
+        (combinedOutput.includes("error") || combinedOutput.includes("Error"));
+      assert.ok(
+        negativeHasError,
+        `negative.astro SHOULD have a type error but exit code was ${checkExitCode}. Output:\n${combinedOutput}`,
+      );
+
+      // Verify the error message mentions the invalid prop name
+      assert.ok(
+        combinedOutput.includes("nonexistentProp"),
+        `The error should mention "nonexistentProp". Output:\n${combinedOutput}`,
+      );
+
+      // Known-prop-on-wrong-constructor fixture: must NOT error (documented
+      // tradeoff — the prop `page` is globally available via IntrinsicAttributes
+      // augmentation).
+      const wrongKnownPropHasError =
+        combinedOutput.includes("wrong-constructor-known-prop.astro") &&
+        (combinedOutput.includes("error") || combinedOutput.includes("Error"));
+      assert.ok(
+        !wrongKnownPropHasError,
+        `wrong-constructor-known-prop.astro should have NO error (known tradeoff) but got:\n${combinedOutput}`,
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- generate Astro SSR constructor typings from `packages/ui/custom-elements.json`
- inject generated declarations from `@grantcodes/astro` and keep them refreshed via package scripts
- add an `astro check` regression test covering valid props, invalid props, and the current cross-component prop caveat

## Testing
- pnpm --filter @grantcodes/astro exec tsx scripts/generate-astro-typings-from-cem.ts
- pnpm --filter @grantcodes/astro test

Closes #150