### PR TITLE
fix(astro): keep generated typings in sync

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,13 @@ jobs:
         run: rm -rf .turbo
 
       - run: pnpm build --force
-        name: Build
+        name: Build (includes CEM regeneration for @grantcodes/ui)
+
+      # Regenerate derived artifacts from the just-built CEM, then verify
+      # the working tree is clean — any diff means a stale generated file
+      # was committed or a regeneration step is broken.
+      - name: Regenerate Astro component typings from CEM
+        run: pnpm --filter @grantcodes/astro gen:props
 
       - name: Check for dirty working tree (generated artifact drift)
         run: git diff --exit-code

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -43,7 +43,17 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
 
       - run: pnpm build
-        name: Run build
+        name: Run build (includes CEM regeneration for @grantcodes/ui)
+        if: ${{ steps.release.outputs.releases_created }}
+
+      # Regenerate derived artifacts from the just-built CEM, then verify
+      # the working tree is clean — any diff aborts the publish.
+      - name: Regenerate Astro component typings from CEM
+        run: pnpm --filter @grantcodes/astro gen:props
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Check for dirty working tree (generated artifact drift)
+        run: git diff --exit-code
         if: ${{ steps.release.outputs.releases_created }}
 
       - name: Publish @grantcodes/ui

--- a/packages/astro/scripts/generate-astro-typings-from-cem.ts
+++ b/packages/astro/scripts/generate-astro-typings-from-cem.ts
@@ -113,11 +113,19 @@ function cemTypeToTs(typeText: string | undefined): string {
   return "unknown";
 }
 
-// Clean a CEM member name: strip surrounding double quotes that Lit uses for
-// hyphenated property names (e.g. `"days-label"` → `days-label`).
+// Clean a CEM member name: strip surrounding single or double quote wrappers.
+//
+// The CEM analyzer wraps hyphenated property names in quotes (single or
+// double) so they remain valid JSON string values (e.g. `"'days-label'"` or
+// `'"days-label"'`).  We must strip those before using the name in TS prop
+// declarations.
 function cleanMemberName(raw: string): string {
   let s = raw.trim();
-  if (s.startsWith('"') && s.endsWith('"')) s = s.slice(1, -1);
+  const first = s[0];
+  const last = s[s.length - 1];
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    s = s.slice(1, -1);
+  }
   return s;
 }
 

--- a/packages/astro/src/generated/ui-component-props.d.ts
+++ b/packages/astro/src/generated/ui-component-props.d.ts
@@ -592,12 +592,6 @@ declare module "@grantcodes/ui/components/stats/index.js" {
 
 declare module "@grantcodes/ui/components/tabs/index.js" {
 
-  export interface TabsProps {
-    label?: string;
-  }
-
-  export function GrantCodesTabs(props: TabsProps & import("astro").AstroBuiltinAttributes): any;
-
   export interface TabProps {
     active?: boolean;
     buttonId?: string;
@@ -609,6 +603,12 @@ declare module "@grantcodes/ui/components/tabs/index.js" {
   }
 
   export function GrantCodesTab(props: TabProps & import("astro").AstroBuiltinAttributes): any;
+
+  export interface TabsProps {
+    label?: string;
+  }
+
+  export function GrantCodesTabs(props: TabsProps & import("astro").AstroBuiltinAttributes): any;
 
   export interface TabsButtonProps {
     active?: boolean;
@@ -622,8 +622,8 @@ declare module "@grantcodes/ui/components/tabs/index.js" {
 
   export function GrantCodesTabsButton(props: TabsButtonProps & import("astro").AstroBuiltinAttributes): any;
 
-  export { GrantCodesTabs };
   export { GrantCodesTab };
+  export { GrantCodesTabs };
   export { GrantCodesTabsButton };
 }
 


### PR DESCRIPTION
## Summary
- Normalize both single- and double-quoted CEM member names in the Astro typings generator
- Regenerate UI component props typings from the current custom-elements manifest
- Verify generated artifacts in both PR CI and the release workflow before publishing

## Verification
- pnpm build --force
- pnpm --filter @grantcodes/astro gen:props
- git diff --exit-code
- pnpm --filter @grantcodes/astro test

This prevents pnpm provenance publishing from reaching an unclean working tree.